### PR TITLE
Add Sidekiq::Config#handle_deprecation

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -103,6 +103,10 @@ module Sidekiq
     @config_blocks = nil
   end
 
+  def self.deprecate(msg)
+    default_configuration.handle_deprecation(msg)
+  end
+
   # Creates a Sidekiq::Config instance that is more tuned for embedding
   # within an arbitrary Ruby process. Notably it reduces concurrency by
   # default so there is less contention for CPU time with other threads.

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -104,7 +104,7 @@ module Sidekiq
   end
 
   def self.deprecate(msg)
-    default_configuration.handle_deprecation(msg)
+    default_configuration.handle_deprecation(msg, caller: caller)
   end
 
   # Creates a Sidekiq::Config instance that is more tuned for embedding

--- a/test/sidekiq_test.rb
+++ b/test/sidekiq_test.rb
@@ -88,7 +88,7 @@ describe Sidekiq do
           raise "DEPRECATION ERROR: #{msg}"
         }
 
-        assert_raises RuntimeError, "DEPRECATION ERROR: everything" do
+        assert_raises RuntimeError, "DEPRECATION ERROR: this thing here" do
           @config.handle_deprecation(RuntimeError.new("this thing here"))
         end
       end

--- a/test/sidekiq_test.rb
+++ b/test/sidekiq_test.rb
@@ -95,6 +95,13 @@ describe Sidekiq do
 
       refute_includes output, "DEPRECATION WARNING: this thing here"
     end
+
+    it "has a top-level method to communicate deprecation that can show where a deprecated call was made from" do
+      output = capture_logging(@config) do
+          Sidekiq.deprecate("this method is going away in Sidekiq 9000.0")
+      end
+      assert_includes output, "DEPRECATION WARNING: this method is going away in Sidekiq 9000.0"
+    end
   end
 
   describe "redis connection" do


### PR DESCRIPTION
A possible implementation for https://github.com/mperham/sidekiq/issues/5743 . It follows the pattern established by `error_handlers`.

The main difference from `error_handlers` is that it only allows _one_ handler. My intention here is that you'd only want one thing to actually output, so it doesn't make sense to allow multiple. My mind can be changed though.

If the approach is generally amenable, there are a few things I'd like to get in before merging:

- [x] include information about the `caller`, so users can find what is causing it
- [x] a public API with more natural name (`Sidekiq.deprecated`?)
- [ ] update existing deprecation warnings to use it