### PR TITLE
Introduce Sidekiq::Deprecation as a way to mark deprecations

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -28,6 +28,7 @@ rescue LoadError
 end
 
 require "sidekiq/config"
+require "sidekiq/deprecation"
 require "sidekiq/logger"
 require "sidekiq/client"
 require "sidekiq/transaction_aware_client"
@@ -101,6 +102,10 @@ module Sidekiq
   def self.freeze!
     @frozen = true
     @config_blocks = nil
+  end
+
+  def self.deprecate(msg)
+    default_configuration.handle_deprecation(msg, caller: caller)
   end
 
   # Creates a Sidekiq::Config instance that is more tuned for embedding

--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -44,7 +44,7 @@ module Sidekiq
     # @param chain [Sidekiq::Middleware::Chain] use the given middleware chain
     def initialize(*args, **kwargs)
       if args.size == 1 && kwargs.size == 0
-        warn "Sidekiq::Client.new(pool) is deprecated, please use Sidekiq::Client.new(pool: pool), #{caller(0..3)}"
+        Sidekiq::Deprecation.warn "Sidekiq::Client.new(pool) is deprecated, please use Sidekiq::Client.new(pool: pool)"
         # old calling method, accept 1 pool argument
         @redis_pool = args[0]
         @chain = Sidekiq.default_configuration.client_middleware

--- a/lib/sidekiq/deprecation.rb
+++ b/lib/sidekiq/deprecation.rb
@@ -1,0 +1,53 @@
+module Sidekiq
+  class Deprecation
+    class << self
+      attr_reader :behavior
+    end
+
+    DEFAULT_BEHAVIORS = {
+      log: ->(msg, callstack, details) {
+        logger = Sidekiq.default_configuration.logger
+        logger.warn "DEPRECATION(#{details}): #{msg} (called from #{callstack[0]})"
+      },
+
+      silence: ->(message, callstack, details) { },
+    }
+
+    def self.behavior=(behavior)
+      if behavior.nil?
+        @behavior = nil
+      elsif DEFAULT_BEHAVIORS.key?(behavior)
+        @behavior = DEFAULT_BEHAVIORS[behavior]
+      elsif behavior.respond_to?(:call)
+        @behavior = behavior
+      else
+        raise ArgumentError, "Don't know how to use #{behavior.inspect}. Expected a Symbol or object that responds to call"
+      end
+    end
+
+    def self.warn(message = nil, callstack = nil, gem_name: "sidekiq", deprecation_horizon: nil)
+      callstack ||= caller
+      details = Details.new(gem_name: gem_name, deprecation_horizon: deprecation_horizon)
+
+      self.behavior ||= DEFAULT_BEHAVIORS[:log]
+      self.behavior.call(message, callstack, details)
+    end
+
+    class Details
+      attr_accessor :gem_name, :deprecation_horizon
+
+      def initialize(gem_name: "sidekiq", deprecation_horizon: nil)
+        @gem_name = gem_name
+        @deprecation_horizon = deprecation_horizon
+      end
+
+      def to_s
+        if deprecation_horizon
+          "#{gem_name}-#{deprecation_horizon}"
+        else
+          gem_name
+        end
+      end
+    end
+  end
+end

--- a/test/deprecation_test.rb
+++ b/test/deprecation_test.rb
@@ -1,0 +1,61 @@
+require_relative "helper"
+
+describe Sidekiq::Deprecation do
+  before do
+    @config = reset!
+
+    Sidekiq::Deprecation.behavior = nil
+  end
+
+  describe "behaviors" do
+    it "can use the logger" do
+      Sidekiq::Deprecation.behavior = :log
+      caller_line = __LINE__ + 2 # the line the handle_deprecation is on
+      output = capture_logging(@config) do
+        Sidekiq::Deprecation.warn "everything!"
+      end
+
+      assert_includes output, "DEPRECATION(sidekiq): everything!"
+      assert_includes output, "called from #{__FILE__}:#{caller_line}"
+    end
+
+    it "can be silenced" do
+      Sidekiq::Deprecation.behavior = :silence
+      caller_line = __LINE__ + 2 # the line the handle_deprecation is on
+      output = capture_logging(@config) do
+        Sidekiq::Deprecation.warn "this thing here"
+      end
+
+      refute_includes output, "DEPRECATION WARNING: this thing here"
+    end
+
+    it "can be assigned a proc or other object that responds to call" do
+      Sidekiq::Deprecation.behavior = proc {|msg, ctx, caller|
+        raise "DEPRECATION ERROR: #{msg}"
+      }
+
+      assert_raises RuntimeError, "DEPRECATION ERROR: this thing here" do
+        Sidekiq::Deprecation.warn "this thing here"
+      end
+    end
+  end
+
+  describe ".warn" do
+    it "can specify a different gem" do
+      output = capture_logging(@config) do
+        Sidekiq::Deprecation.warn("this method is being removed", gem_name: "sidekiq-awesome")
+      end
+
+      assert_includes output, "DEPRECATION(sidekiq-awesome): this method is being removed"
+    end
+
+    it "can specify a deprecation horizon" do
+      output = capture_logging(@config) do
+        Sidekiq::Deprecation.warn("this method is being removed", deprecation_horizon: "9000.0")
+      end
+
+      assert_includes output, "DEPRECATION(sidekiq-9000.0): this method is being removed"
+    end
+  end
+end
+

--- a/test/deprecation_test.rb
+++ b/test/deprecation_test.rb
@@ -62,6 +62,14 @@ describe Sidekiq::Deprecation do
 
       assert_includes output, "DEPRECATION(sidekiq-9000.0): this method is being removed"
     end
+
+    it "can be given docs to reference" do
+      output = capture_logging(@config) do
+        Sidekiq::Deprecation.warn("this method is being removed", deprecation_horizon: "9000.0", see_docs: "https://github.com/mperham/sidekiq/wiki/Over9000")
+      end
+
+      assert_includes output, "DEPRECATION(sidekiq-9000.0): this method is being removed. See https://github.com/mperham/sidekiq/wiki/Over9000 for details."
+    end
   end
 end
 

--- a/test/deprecation_test.rb
+++ b/test/deprecation_test.rb
@@ -38,6 +38,12 @@ describe Sidekiq::Deprecation do
         Sidekiq::Deprecation.warn "this thing here"
       end
     end
+
+    it "errors on non-symbols and non-callable objects" do
+      assert_raises ArgumentError, /expected symbol or object that responds to call/i do
+        Sidekiq::Deprecation.behavior = "not a symbol or callable"
+      end
+    end
   end
 
   describe ".warn" do


### PR DESCRIPTION
This is a different take on https://github.com/mperham/sidekiq/pull/5745 to address https://github.com/mperham/sidekiq/issues/5743 This borrows a ton from ActiveSupport::Deprecation.

For Sidekiq contributors, they can use like:

```ruby
Sidekiq::Deprecation.warn "this thing is changing, blah balh"
```

And Sidekiq extension developers can utilize it too:

```ruby
Sidekiq::Deprecation.warn "this other thing changes soon", gem_name: "sidekiq-awesomeness"
```

Either of these uses can also specify the deprecation horizon, when it is going away:

```
Sidekiq::Deprecation.warn "this thing is changing, blah balh", deprecation_horizon: "8.0"
```

Users of Sidekiq can configure the behavior when these come in. The default is so use Sidekiq.logger.warn. It takes a symbol for a name of a predefined logger (:log, :silence), or an object that responds to call (ie a lambda/proc/etc or your own class defining it):

```ruby
Sidekiq::Deprecation.behavior = proc {|msg, callstack, details|
  puts "#{details.gem_name} deprecation:"
  puts "for version #{details.deprecation_horizon}" if details.deprecation_horizon
  puts msg
  puts callstack
}
```

---

Some follow on things I'm still thinking about:

- the API is a little different than
- thinking to include a ActiveSupport::Deprecation behavior out of the box. That would just mean a development dependency on it to validate
- maybe Rails should default to that too?