### PR TITLE
Adjust push_bulk return value

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -128,10 +128,11 @@ module Sidekiq
           copy
         end
         result || nil
-      }.compact
+      }
 
-      raw_push(payloads) unless payloads.empty?
-      payloads.collect { |payload| payload["jid"] }
+      to_push = payloads.compact
+      raw_push(to_push) unless to_push.empty?
+      payloads.map { |payload| payload&.[]("jid") }
     end
 
     # Allows sharding of jobs across any number of Redis instances.  All jobs

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -124,7 +124,8 @@ describe Sidekiq::Client do
       q = Sidekiq::Queue.new
       q.clear
       result = @client.push_bulk("class" => "Blah", "args" => [[1], [2], [3]])
-      assert_equal 1, result.size
+      assert_equal 3, result.size
+      assert_equal [24, 0, 0], result.map(&:to_s).map(&:size)
       assert_equal 1, q.size
     end
 
@@ -430,9 +431,10 @@ describe Sidekiq::Client do
 
       assert_nil @client.push("class" => MyJob, "args" => [0])
       assert_match(/[0-9a-f]{12}/, @client.push("class" => MyJob, "args" => [1]))
-      @client.push_bulk("class" => MyJob, "args" => [[0], [1]]).each do |jid|
-        assert_match(/[0-9a-f]{12}/, jid)
-      end
+      result = @client.push_bulk("class" => MyJob, "args" => [[0], [1]])
+      assert_equal 2, result.size
+      refute result[0]
+      assert_match(/[0-9a-f]{12}/, result[1])
     end
   end
 


### PR DESCRIPTION
Previously we only returned the JIDs that were succesfully pushed but there was no way for the caller to determine which payloads, if any were not successfully pushed.

Now we return both nils and JIDs. If you push 5 jobs, you will get 5 results even if all five did not get pushed. This change is helpful for the upcoming ActiveJob bulk enqueue helper method so AJ can know which jobs pushed successfully.

See rails/rails#46603