### PR TITLE
Fix detecting json unsafe item within job arguments

### DIFF
--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -98,12 +98,19 @@ module Sidekiq
       when String, Integer, Float, TrueClass, FalseClass, NilClass
         nil
       when Array
-        item.find { |e| !json_unsafe_item(e).nil? }
+        item.each do |e|
+          unsafe_item = json_unsafe_item(e)
+          return unsafe_item unless unsafe_item.nil?
+        end
+        nil
       when Hash
         item.each do |k, v|
           return k unless String === k
-          return v unless json_unsafe_item(v).nil?
+
+          unsafe_item = json_unsafe_item(v)
+          return unsafe_item unless unsafe_item.nil?
         end
+        nil
       else
         item
       end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -243,7 +243,7 @@ describe Sidekiq::Client do
         end
 
         it "raises an error when using a Hash with symbols and string as keys as an argument" do
-          assert_raises ArgumentError do
+          error = assert_raises ArgumentError do
             InterestingJob.perform_async(
               {
                 :some => "hash",
@@ -251,6 +251,7 @@ describe Sidekiq::Client do
               }
             )
           end
+          assert_match(/but :some is a Symbol/, error.message)
         end
 
         it "raises an error when using a Struct as an argument" do


### PR DESCRIPTION
I apologize, I realized that I made a mistake in https://github.com/sidekiq/sidekiq/pull/5786.

Code like 
```ruby
when Array
  item.find { |e| !json_unsafe_item(e).nil? }
```
incorrectly returns *the child* of an array if it is not valid or has invalid children, instead of the innermost child - see the updated test case. The code became a little more uglier, but this time should work as expected.