### PR TITLE
Handle correctly subclasses when finding json unsafe item

### DIFF
--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -62,6 +62,13 @@ end
 class DJob < BaseJob
 end
 
+class ChildHash < Hash
+  def initialize(constructor)
+    super
+    update(constructor)
+  end
+end
+
 describe Sidekiq::Client do
   before do
     @config = reset!
@@ -252,6 +259,13 @@ describe Sidekiq::Client do
             )
           end
           assert_match(/but :some is a Symbol/, error.message)
+        end
+
+        it "raises an error when using a Hash subclass" do
+          error = assert_raises ArgumentError do
+            InterestingJob.perform_async(ChildHash.new("some" => "hash"))
+          end
+          assert_includes(error.message, 'but {"some"=>"hash"} is a ChildHash')
         end
 
         it "raises an error when using a Struct as an argument" do


### PR DESCRIPTION
Fixes #5789.

HWIA is correctly detected as unsafe, but there is a problem in detecting the culprit. We can not use a `case-when`, because it checks for instances of classes (*or subclasses*), which is not correct in this case 🤦 We need to do exact comparison.

Am I missing any other test cases, so this won't happen again? 🤔 