### PR TITLE
Exception logging with Rails backtrace cleaner

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -71,6 +71,7 @@ module Sidekiq
     def initialize(capsule)
       @config = @capsule = capsule
       @max_retries = Sidekiq.default_configuration[:max_retries] || DEFAULT_MAX_RETRY_ATTEMPTS
+      @backtrace_cleaner = Sidekiq.default_configuration[:backtrace_cleaner]
     end
 
     # The global retry handler requires only the barest of data.
@@ -159,10 +160,11 @@ module Sidekiq
       end
 
       if msg["backtrace"]
+        backtrace = @backtrace_cleaner.call(exception.backtrace)
         lines = if msg["backtrace"] == true
-          exception.backtrace
+          backtrace
         else
-          exception.backtrace[0...msg["backtrace"].to_i]
+          backtrace[0...msg["backtrace"].to_i]
         end
 
         msg["error_backtrace"] = compress_backtrace(lines)

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -50,6 +50,12 @@ module Sidekiq
       end
     end
 
+    initializer "sidekiq.backtrace_cleaner" do
+      Sidekiq.configure_server do |config|
+        config[:backtrace_cleaner] = ::Rails.backtrace_cleaner
+      end
+    end
+
     # This hook happens after all initializers are run, just before returning
     # from config/environment.rb back to sidekiq/cli.rb.
     #
@@ -59,5 +65,9 @@ module Sidekiq
         config[:reloader] = Sidekiq::Rails::Reloader.new
       end
     end
+  end
+
+  ActiveSupport::BacktraceCleaner.class_eval do
+    alias :call :clean
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -36,6 +36,7 @@ def reset!
 
   RedisClient.new(url: ENV["REDIS_URL"]).call("flushall")
   cfg = Sidekiq::Config.new
+  cfg[:backtrace_cleaner] = Sidekiq::Config::DEFAULTS[:backtrace_cleaner]
   cfg.logger = NULL_LOGGER
   cfg.logger.level = Logger::WARN
   Sidekiq.instance_variable_set :@config, cfg

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -12,6 +12,7 @@ describe "ActiveJob" do
     ActiveJob::Base.queue_adapter = :sidekiq
     ActiveJob::Base.logger = nil
     ActiveJob::Base.send(:include, ::Sidekiq::Job::Options) unless ActiveJob::Base.respond_to?(:sidekiq_options)
+    @config[:backtrace_cleaner] = Rails.backtrace_cleaner
   end
 
   it "does not allow Sidekiq::Job in AJ::Base classes" do

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -182,6 +182,22 @@ describe Sidekiq::JobRetry do
       assert_equal 3, c.size
     end
 
+    it "cleans backtraces" do
+      @config[:backtrace_cleaner] = ->(backtrace) { backtrace.take(1) }
+
+      assert_raises RuntimeError do
+        handler.local(worker, jobstr("backtrace" => true), "default") do
+          raise("kerblammo!")
+        end
+      end
+
+      job = Sidekiq::RetrySet.new.first
+      assert job.error_backtrace
+      assert_equal 1, job.error_backtrace.size
+    ensure
+      @config[:backtrace_cleaner] = Sidekiq::Config::DEFAULTS[:backtrace_cleaner]
+    end
+
     it "handles a new failed message" do
       assert_raises RuntimeError do
         handler.local(worker, jobstr, "default") do


### PR DESCRIPTION
Closes #5589.

Backtrace cleaning applies to exception logging and backtraces stored within the jobs.