### PR TITLE
Wrap the Rails backtrace cleaner to avoid aliasing method

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -52,7 +52,7 @@ module Sidekiq
 
     initializer "sidekiq.backtrace_cleaner" do
       Sidekiq.configure_server do |config|
-        config[:backtrace_cleaner] = ::Rails.backtrace_cleaner
+        config[:backtrace_cleaner] = ->(backtrace) { ::Rails.backtrace_cleaner.clean(backtrace) }
       end
     end
 
@@ -65,9 +65,5 @@ module Sidekiq
         config[:reloader] = Sidekiq::Rails::Reloader.new
       end
     end
-  end
-
-  ActiveSupport::BacktraceCleaner.class_eval do
-    alias :call :clean
   end
 end

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -12,7 +12,7 @@ describe "ActiveJob" do
     ActiveJob::Base.queue_adapter = :sidekiq
     ActiveJob::Base.logger = nil
     ActiveJob::Base.send(:include, ::Sidekiq::Job::Options) unless ActiveJob::Base.respond_to?(:sidekiq_options)
-    @config[:backtrace_cleaner] = Rails.backtrace_cleaner
+    @config[:backtrace_cleaner] = ->(backtrace) { Rails.backtrace_cleaner.clean(backtrace) }
   end
 
   it "does not allow Sidekiq::Job in AJ::Base classes" do


### PR DESCRIPTION
By wrapping the `Rails.backtrace_cleaner` with a proc/lambda and call `clean` ourselves, we can avoid the monkey-patch/extension to alias the method in the backtrace cleaner implementation so that it conforms to the `call` API.

Ref: https://github.com/sidekiq/sidekiq/pull/5794#discussion_r1109767123

/cc @fatkodima 