### PR TITLE
Change recommended constraint to `~> 6` from `< 7`

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
     
     Welcome to Sidekiq 7.0!
     
-    1. Use `gem 'sidekiq', '<7'` in your Gemfile if you don't want this new version.
+    1. Use `gem 'sidekiq', '~> 6'` in your Gemfile if you don't want this new version.
     2. Read the release notes at https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md
     3. If you have problems, search for open/closed issues at https://github.com/sidekiq/sidekiq/issues/
 


### PR DESCRIPTION
The scope of the `< 7` constraint includes `7.0.0.beta1` which may surprise users expecting 6.x.x to be installed.