### PR TITLE
Fix uninitialized constant Sidekiq::Capsule (NameError) 

### DIFF
--- a/lib/sidekiq/config.rb
+++ b/lib/sidekiq/config.rb
@@ -1,6 +1,7 @@
 require "forwardable"
 
 require "set"
+require "sidekiq/capsule"
 require "sidekiq/redis_connection"
 
 module Sidekiq


### PR DESCRIPTION
Right now if you will try to access default capsule in the code like this `Sidekiq.default_configuration.default_capsule` you will get this error because `capsule` is not required in the config file
```irb
development> Sidekiq.default_configuration.default_capsule
/Users/myuser/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/sidekiq-7.0.6/lib/sidekiq/config.rb:107:in `block in capsule': uninitialized constant Sidekiq::Capsule (NameError)   

        cap = Sidekiq::Capsule.new(nm, self)
                     ^^^^^^^^^
```