### PR TITLE
Pass a timeout to blocking_call

### DIFF
--- a/lib/sidekiq/fetch.rb
+++ b/lib/sidekiq/fetch.rb
@@ -44,7 +44,7 @@ module Sidekiq # :nodoc:
         return nil
       end
 
-      queue, job = redis { |conn| conn.blocking_call(false, "brpop", *qs, TIMEOUT) }
+      queue, job = redis { |conn| conn.blocking_call(TIMEOUT + 1, "brpop", *qs, TIMEOUT) }
       UnitOfWork.new(queue, job, config) if queue
     end
 


### PR DESCRIPTION
`false` means no timeout, so if for some reason the server never respond the client will be stuck forever.

This may mitigate https://github.com/redis-rb/redis-client/issues/96