### PR TITLE
Show ActionMailer params as the job arguments

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -397,7 +397,7 @@ module Sidekiq
           job_args.drop(3)
         elsif (self["wrapped"] || args[0]) == "ActionMailer::MailDeliveryJob"
           # remove MailerClass, mailer_method and 'deliver_now'
-          job_args.drop(3).first["args"]
+          job_args.drop(3).first.values_at("params", "args")
         else
           job_args
         end

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -31,7 +31,7 @@ SERIALIZED_JOBS = {
   ],
   "6.x" => [
     '{"class":"ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper","wrapped":"ApiAjJob","queue":"default","args":[{"job_class":"ApiAjJob","job_id":"ff2b48d4-bdce-4825-af6b-ef8c11ab651e","provider_job_id":null,"queue_name":"default","priority":null,"arguments":[1,2,3],"executions":0,"exception_executions":{},"locale":"en","timezone":"UTC","enqueued_at":"2019-09-12T16:28:37Z"}],"retry":true,"jid":"ce121bf77b37ae81fe61b6dc","created_at":1568305717.9469702,"enqueued_at":1568305717.947005}',
-    '{"class":"ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper","wrapped":"ActionMailer::MailDeliveryJob","queue":"mailers","args":[{"job_class":"ActionMailer::MailDeliveryJob","job_id":"2f967da1-a389-479c-9a4e-5cc059e6d65c","provider_job_id":null,"queue_name":"mailers","priority":null,"arguments":["ApiMailer","test_email","deliver_now",{"args":[1,2,3],"_aj_symbol_keys":["args"]}],"executions":0,"exception_executions":{},"locale":"en","timezone":"UTC","enqueued_at":"2019-09-12T16:28:37Z"}],"retry":true,"jid":"469979df52bb9ef9f48b49e1","created_at":1568305717.9457421,"enqueued_at":1568305717.9457731}'
+    '{"class":"ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper","wrapped":"ActionMailer::MailDeliveryJob","queue":"mailers","args":[{"job_class":"ActionMailer::MailDeliveryJob","job_id":"2f967da1-a389-479c-9a4e-5cc059e6d65c","provider_job_id":null,"queue_name":"mailers","priority":null,"arguments":["ApiMailer","test_email","deliver_now",{"params":{"user":{"_aj_globalid":"gid://app/User/1"}, "_aj_symbol_keys":["user"]},"args":[1,2,3],"_aj_symbol_keys":["params", "args"]}],"executions":0,"exception_executions":{},"locale":"en","timezone":"UTC","enqueued_at":"2019-09-12T16:28:37Z"}],"retry":true,"jid":"469979df52bb9ef9f48b49e1","created_at":1568305717.9457421,"enqueued_at":1568305717.9457731}'
   ]
 }
 
@@ -294,8 +294,13 @@ describe "API" do
           # ApiMailer.test_email(1,2,3).deliver_later
           # puts Sidekiq::Queue.new("mailers").first.value
           x = Sidekiq::JobRecord.new(jobs[1], "mailers")
+
+          expected_args_by_version = {
+            "5.x" => [1, 2, 3],
+            "6.x" => [{"user" => "gid://app/User/1"}, [1, 2, 3]]
+          }
           assert_equal "#{ApiMailer.name}#test_email", x.display_class
-          assert_equal [1, 2, 3], x.display_args
+          assert_equal expected_args_by_version[ver], x.display_args
         end
       end
     end


### PR DESCRIPTION
[Rails 5.1](https://guiarails.com.br/5_1_release_notes.html#parameterized-mailers) added the ability to pass data to mailers as params, which is also the current recommended way in [the guides](https://guides.rubyonrails.org/action_mailer_basics.html#calling-the-mailer).

Most of the time, emails are delivered immediately, so they exit the queue pretty quick, but sometimes you want to schedule a sending in the future (with `deliver_later(wait: ...)`) and the job might stay around for a while.

It'd be helpful to be able to see the params that are associated to the job, as at the moment it only shows the args, which might be empty most of the time (if you use params instead).

This changes it to show both of them.