### PR TITLE
`Sidekiq::Client.push_bulk` works in batches

### DIFF
--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -9,7 +9,7 @@ module Sidekiq
 
     def validate(item)
       raise(ArgumentError, "Job must be a Hash with 'class' and 'args' keys: `#{item}`") unless item.is_a?(Hash) && item.key?("class") && item.key?("args")
-      raise(ArgumentError, "Job args must be an Array: `#{item}`") unless item["args"].is_a?(Array)
+      raise(ArgumentError, "Job args must be an Array: `#{item}`") unless item["args"].is_a?(Array) || item["args"].is_a?(Enumerator::Lazy)
       raise(ArgumentError, "Job class must be either a Class or String representation of the class name: `#{item}`") unless item["class"].is_a?(Class) || item["class"].is_a?(String)
       raise(ArgumentError, "Job 'at' must be a Numeric timestamp: `#{item}`") if item.key?("at") && !item["at"].is_a?(Numeric)
       raise(ArgumentError, "Job tags must be an Array: `#{item}`") if item["tags"] && !item["tags"].is_a?(Array)

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -322,13 +322,26 @@ describe Sidekiq::Client do
     end
 
     it "can push a large set of jobs at once" do
-      jids = Sidekiq::Client.push_bulk("class" => QueuedJob, "args" => (1..1_000).to_a.map { |x| Array(x) })
-      assert_equal 1_000, jids.size
+      jids = Sidekiq::Client.push_bulk("class" => QueuedJob, "args" => (1..1_001).to_a.map { |x| Array(x) })
+      assert_equal 1_001, jids.size
     end
 
     it "can push a large set of jobs at once using a String class" do
-      jids = Sidekiq::Client.push_bulk("class" => "QueuedJob", "args" => (1..1_000).to_a.map { |x| Array(x) })
-      assert_equal 1_000, jids.size
+      jids = Sidekiq::Client.push_bulk("class" => "QueuedJob", "args" => (1..1_001).to_a.map { |x| Array(x) })
+      assert_equal 1_001, jids.size
+    end
+
+    it "pushes a large set of jobs with a different batch size" do
+      jids = Sidekiq::Client.push_bulk("class" => QueuedJob, "args" => (1..1_001).to_a.map { |x| Array(x) }, :batch_size => 100)
+      assert_equal 1_001, jids.size
+    end
+
+    describe "lazy enumerator" do
+      it "enqueues the jobs by evaluating the enumerator" do
+        lazy_array = (1..1_001).to_a.map { |x| Array(x) }.lazy
+        jids = Sidekiq::Client.push_bulk("class" => QueuedJob, "args" => lazy_array)
+        assert_equal 1_001, jids.size
+      end
     end
 
     [1, 2, 3].each do |job_count|


### PR DESCRIPTION
Fixes #5814.

Example of usage:
```ruby
push_bulk('class' => 'MyJob', 'args' => (1..100_000).to_a) # will push into redis in batches of size 1000
push_bulk('class' => 'MyJob', 'args' => (1..100_000).to_a, batch_size: 10_000)
```

[Nicer diff without whitespace changes](https://github.com/sidekiq/sidekiq/pull/5827/files?diff=split&w=1)