### PR TITLE
Add ability to log source locations from where the job was enqueued

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,8 @@
 7.1.0
 ----------
 
+- Sidekiq can optionally log source locations from where the job was enqueued.
+  Just include `require 'sidekiq/middleware/enqueue_source_logger'` in your sidekiq initializer [#5833, fatkodima]
 - Improve display of ActiveJob arguments in Web UI [#5825, cover]
 - Update `push_bulk` to push `batch_size` jobs at a time and allow laziness [#5827, fatkodima]
   This allows Sidekiq::Client to push unlimited jobs as long as it has enough memory for the batch_size.

--- a/lib/sidekiq/middleware/enqueue_source_logger.rb
+++ b/lib/sidekiq/middleware/enqueue_source_logger.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#
+# Simple middleware to log source locations from where the job was enqueued.
+# Use it by requiring it in your initializer:
+#
+#     require 'sidekiq/middleware/enqueue_source_logger'
+#
+module Sidekiq
+  module Middleware
+    class EnqueueSourceLogger
+      include Sidekiq::ClientMiddleware
+
+      def call(jobclass, _job, _queue, _pool)
+        source = extract_enqueue_source_location(caller)
+        logger.info(<<~EOM)
+          #{jobclass} enqueued
+            ↳ #{source}
+        EOM
+
+        yield
+      end
+
+      private
+
+      def extract_enqueue_source_location(locations)
+        backtrace_cleaner = Sidekiq.default_configuration[:backtrace_cleaner]
+        backtrace_cleaner.call(locations.lazy).first
+      end
+    end
+  end
+end
+
+Sidekiq.configure_client do |config|
+  config.client_middleware do |chain|
+    chain.add Sidekiq::Middleware::EnqueueSourceLogger
+  end
+end
+
+Sidekiq.configure_server do |config|
+  config.client_middleware do |chain|
+    chain.add Sidekiq::Middleware::EnqueueSourceLogger
+  end
+end

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -51,9 +51,8 @@ module Sidekiq
     end
 
     initializer "sidekiq.backtrace_cleaner" do
-      Sidekiq.configure_server do |config|
-        config[:backtrace_cleaner] = ->(backtrace) { ::Rails.backtrace_cleaner.clean(backtrace) }
-      end
+      Sidekiq.default_configuration[:backtrace_cleaner] =
+        ->(backtrace) { ::Rails.backtrace_cleaner.clean(backtrace) }
     end
 
     # This hook happens after all initializers are run, just before returning

--- a/test/dummy/app/jobs/dummy_job.rb
+++ b/test/dummy/app/jobs/dummy_job.rb
@@ -1,0 +1,6 @@
+class DummyJob
+  include Sidekiq::Job
+
+  def perform
+  end
+end

--- a/test/dummy/app/services/dummy_service.rb
+++ b/test/dummy/app/services/dummy_service.rb
@@ -1,0 +1,7 @@
+require_relative "../jobs/dummy_job"
+
+class DummyService
+  def self.do_something
+    DummyJob.perform_async
+  end
+end

--- a/test/enqueue_source_logger_test.rb
+++ b/test/enqueue_source_logger_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "./helper"
+require_relative "./dummy/app/services/dummy_service"
+
+describe "EnqueueSourceLogger" do
+  before do
+    require "sidekiq/middleware/enqueue_source_logger"
+  end
+
+  it "logs enqueue source" do
+    config = Sidekiq.default_configuration
+    previous_cleaner = config[:backtrace_cleaner]
+    config[:backtrace_cleaner] = ->(backtrace) { backtrace.select { |line| line.include?("dummy/app/") } }
+
+    output = capture_logging(config) do
+      DummyService.do_something
+    end
+
+    assert_match(/DummyJob enqueued\n\s+↳ .+:\d+:in `do_something/, output)
+  ensure
+    config[:backtrace_cleaner] = previous_cleaner
+  end
+end


### PR DESCRIPTION
Closes #5390.

For example,
```ruby
# app/models/user.rb
class User < ApplicationRecord
  def do_hard_work
    HardJob.perform_async
  end
end

# app/sidekiq/hard_job.rb
class HardJob
  include Sidekiq::Job

  def perform
    EasyJob.perform_async
    EasyJob.perform_async
    EasyJob.perform_async
  end
end

# app/sidekiq/easy_job.rb
class EasyJob
  include Sidekiq::Job

  def perform
  end
end
```

Running
```ruby
User.last.do_hard_work
```

Prints
```
2023-03-16T02:00:45.143Z pid=86558 tid=1x5i INFO: Sidekiq 7.1.0 connecting to Redis with options {:size=>5, :pool_name=>"internal", :url=>nil}
2023-03-16T02:00:45.144Z pid=86558 tid=1x5i INFO: HardJob enqueued
  ↳ app/models/user.rb:3:in `do_hard_work'

=> "74a77550f69f43e6465aa43d"
```

When `HardJob` is running by sidekiq, it prints
```
2023-03-16T02:00:45.146Z pid=86333 tid=1zup class=HardJob jid=74a77550f69f43e6465aa43d INFO: start
2023-03-16T02:00:45.160Z pid=86333 tid=1zup class=HardJob jid=74a77550f69f43e6465aa43d INFO: EasyJob enqueued
  ↳ app/sidekiq/hard_job.rb:5:in `perform'

2023-03-16T02:00:45.160Z pid=86333 tid=1zup class=HardJob jid=74a77550f69f43e6465aa43d INFO: EasyJob enqueued
  ↳ app/sidekiq/hard_job.rb:6:in `perform'

2023-03-16T02:00:45.161Z pid=86333 tid=1zup class=HardJob jid=74a77550f69f43e6465aa43d INFO: EasyJob enqueued
  ↳ app/sidekiq/hard_job.rb:7:in `perform'

2023-03-16T02:00:45.162Z pid=86333 tid=1zup class=HardJob jid=74a77550f69f43e6465aa43d elapsed=0.015 INFO: done
```