### PR TITLE
Remove Ruby 2.1 version check

### DIFF
--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -124,8 +124,6 @@ describe Sidekiq::JobRetry do
     end
 
     it "handles zany characters in error message, #1705" do
-      skip "skipped! test requires ruby 2.1+" if RUBY_VERSION <= "2.1.0"
-
       assert_raises RuntimeError do
         handler.local(worker, jobstr, "default") do
           raise "kerblammo! #{195.chr}"


### PR DESCRIPTION
Minor update in test suite.
Test suite runs from Ruby >=2.7  so this check should not be needed