### PR TITLE
Histogram tooltip sort order should match the bubbles on the chart

### DIFF
--- a/lib/sidekiq/metrics/query.rb
+++ b/lib/sidekiq/metrics/query.rb
@@ -70,7 +70,7 @@ module Sidekiq
             result.job_results[klass].add_metric "ms", time, ms.to_i if ms
             result.job_results[klass].add_metric "p", time, p.to_i if p
             result.job_results[klass].add_metric "f", time, f.to_i if f
-            result.job_results[klass].add_hist time, Histogram.new(klass).fetch(conn, time)
+            result.job_results[klass].add_hist time, Histogram.new(klass).fetch(conn, time).reverse
             time -= 60
           end
         end

--- a/test/metrics_test.rb
+++ b/test/metrics_test.rb
@@ -156,8 +156,8 @@ describe Sidekiq::Metrics do
       assert_equal %w[p ms s].sort, job_result.totals.keys.sort
       assert_equal 1, job_result.series.dig("p", "22:03")
       assert_equal 4, job_result.totals["p"]
-      assert_equal 2, job_result.hist.dig("22:02", 0)
-      assert_equal 1, job_result.hist.dig("22:02", 1)
+      assert_equal 2, job_result.hist.dig("22:02", -1)
+      assert_equal 1, job_result.hist.dig("22:02", -2)
     end
   end
 end

--- a/web/views/metrics_for_job.erb
+++ b/web/views/metrics_for_job.erb
@@ -6,11 +6,11 @@
 <%
   job_result = @query_result.job_results[@name]
   hist_totals = job_result.hist.values.first.zip(*job_result.hist.values[1..-1]).map(&:sum)
-  bucket_labels =Sidekiq::Metrics::Histogram::LABELS
-  bucket_intervals =Sidekiq::Metrics::Histogram::BUCKET_INTERVALS.reverse
+  bucket_labels = Sidekiq::Metrics::Histogram::LABELS
+  bucket_intervals = Sidekiq::Metrics::Histogram::BUCKET_INTERVALS
 
   # Replace INFINITY since it can't be represented as JSON
-  bucket_intervals[0] = bucket_intervals[1] * 2
+  bucket_intervals[-1] = bucket_intervals[-2] * 2
 %>
 
 <% if job_result.totals["s"] > 0 %>


### PR DESCRIPTION
Fixes #5865

Before:

Tooltips items were sorted from fastest to slowest, while on the chart the fastest bubbles are on the bottom.

<img width="287" alt="CleanShot 2023-04-07 at 08 15 32@2x" src="https://user-images.githubusercontent.com/372/230607223-6ddf95a1-9151-45d2-b60c-7d8d0d6d7553.png">

After:

Tooltip items are sorted from slowest to fastest, matching the bubbles on the chart.

<img width="800" alt="CleanShot 2023-04-07 at 08 15 45@2x" src="https://user-images.githubusercontent.com/372/230607253-49dac35a-ff9b-40c3-83fd-8e349f87e6de.png">
