### PR TITLE
BasicFetch: wait for an extra `conn.read_timeout`

### DIFF
--- a/lib/sidekiq/fetch.rb
+++ b/lib/sidekiq/fetch.rb
@@ -44,7 +44,7 @@ module Sidekiq # :nodoc:
         return nil
       end
 
-      queue, job = redis { |conn| conn.blocking_call(TIMEOUT + 1, "brpop", *qs, TIMEOUT) }
+      queue, job = redis { |conn| conn.blocking_call(conn.read_timeout + TIMEOUT, "brpop", *qs, TIMEOUT) }
       UnitOfWork.new(queue, job, config) if queue
     end
 


### PR DESCRIPTION
Followup: https://github.com/sidekiq/sidekiq/pull/5823

Some users may have slow network, we shouldn't assume how long we should wait before considering the server timed out.