### PR TITLE
redis 5

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
     "source_code_uri" => "https://github.com/mperham/sidekiq"
   }
 
-  gem.add_dependency "redis", ["<5", ">= 4.5.0"]
+  gem.add_dependency "redis", [">= 4.5.0", "!= 5.0.0"]
   gem.add_dependency "connection_pool", ["<3", ">= 2.2.5"]
   gem.add_dependency "rack", "~> 2.0"
 end

--- a/test/test_redis_connection.rb
+++ b/test/test_redis_connection.rb
@@ -132,11 +132,7 @@ describe Sidekiq::RedisConnection do
         pool = Sidekiq::RedisConnection.create
         redis = pool.checkout
 
-        if self.class.redis_client?
-          assert_equal 1.0, client_for(redis).read_timeout
-        else
-          assert_equal 5, client_for(redis).read_timeout
-        end
+        assert_equal 1.0, client_for(redis).read_timeout
       end
     end
 


### PR DESCRIPTION
I'm trying to upgrade to redis 5 but can't because sidekiq [pins](https://github.com/sidekiq/sidekiq/blob/6-x/sidekiq.gemspec#L25) the version.  The constraint was added [here](https://github.com/sidekiq/sidekiq/commit/d566154107e6543ccb42e0d2e7eddfb529f0933e) due to a compatibility issue.  Fortunately, [redis 5.0.1](https://github.com/redis/redis-rb/commit/7fbd60a0f16c6828f19a6a2824ffe155c83d3ec7) introduced a backwards compatibility fix.

I would love to upgrade to Sidekiq 7, but can't because of the [known issue](https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md#known-issues) of certain [redis cloud providers](https://github.com/sidekiq/sidekiq/issues/5594) lacking support.

Could we please relax the sidekiq constraint for redis so folks can upgrade the two libraries independently?  🙏🏻 
