### PR TITLE
Use input attribute over button on busy view

### DIFF
--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -83,6 +83,20 @@ describe Sidekiq::Web do
       assert_match(/WebJob/, last_response.body)
     end
 
+    it "can quiet all processes" do
+      identity = "identity"
+      signals_key = "#{identity}-signals"
+      @config.redis do |conn|
+        conn.sadd("processes", [identity])
+        conn.hmset(identity, "info", Sidekiq.dump_json("hostname" => "foo", "identity" => identity), "at", Time.now.to_f, "busy", 0)
+      end
+
+      assert_nil @config.redis { |c| c.lpop signals_key }
+      post "/busy", "quiet" => "Quiet All"
+      assert_equal 302, last_response.status
+      assert_equal "TSTP", @config.redis { |c| c.lpop signals_key }
+    end
+
     it "can quiet a process" do
       identity = "identity"
       signals_key = "#{identity}-signals"

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -33,8 +33,8 @@
     <form method="POST" class="warning-messages">
       <%= csrf_tag %>
       <div class="btn-group pull-right flip">
-        <button class="btn btn-warn" type="submit" name="quiet" value="1" data-confirm="<%= t('AreYouSure') %>"><%= t('QuietAll') %></button>
-        <button class="btn btn-danger" type="submit" name="stop" value="1" data-confirm="<%= t('AreYouSure') %>"><%= t('StopAll') %></button>
+        <input class="btn btn-warn" type="submit" name="quiet" value="<%= t('QuietAll') %>" data-confirm="<%= t('AreYouSure') %>"/>
+        <input class="btn btn-danger" type="submit" name="stop" value="<%= t('StopAll') %>" data-confirm="<%= t('AreYouSure') %>"/>
       </div>
     </form>
   </div>


### PR DESCRIPTION
Switch buttons to input attributes, so they get the JS listener that provides the confirmation dialog.

Fixes https://github.com/sidekiq/sidekiq/issues/5878

<img width="1028" alt="Screenshot 2023-04-18 at 11 35 20 AM" src="https://user-images.githubusercontent.com/457431/232632862-25fb3b0a-203b-4a76-bf09-b26a3a209b4e.png">
