### PR TITLE
Enable trimming trailing newlines in ERB with -%>

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -396,7 +396,7 @@ module Sidekiq # :nodoc:
     end
 
     def parse_config(path)
-      erb = ERB.new(File.read(path))
+      erb = ERB.new(File.read(path), trim_mode: "-")
       erb.filename = File.expand_path(path)
       opts = YAML.safe_load(erb.result, permitted_classes: [Symbol], aliases: true) || {}
 


### PR DESCRIPTION
This is mostly as a developer convenience - ERB in Rails is configured this way by default, and I was _assuming_ it was the default, generally speaking. But it's not. And so I spent many confused minutes thinking I was holding Sidekiq wrong. 😆

This is particularly helpful when trying to generate a list of queues, but not wanting extra new lines (which the YAML loader will ignore, but my dumb human brain doesn't want to ignore).

```yaml
:queues:
  <% DEFAULT_JOB_QUEUES.each do |name, weight| -%>
  - ["<%= name %>", <%= weight %>]
  <% end -%>
```