### PR TITLE
Fix order in histogram totals chart

### DIFF
--- a/web/views/metrics_for_job.erb
+++ b/web/views/metrics_for_job.erb
@@ -5,7 +5,7 @@
 
 <%
   job_result = @query_result.job_results[@name]
-  hist_totals = job_result.hist.values.first.zip(*job_result.hist.values[1..-1]).map(&:sum)
+  hist_totals = job_result.hist.values.first.zip(*job_result.hist.values[1..-1]).map(&:sum).reverse
   bucket_labels = Sidekiq::Metrics::Histogram::LABELS
   bucket_intervals = Sidekiq::Metrics::Histogram::BUCKET_INTERVALS
 %>


### PR DESCRIPTION
After installing [Sidekiq 7.0.9](https://github.com/sidekiq/sidekiq/blob/main/Changes.md#709) I noticed that the histogram totals chart was displaying the data in the wrong order:

![Screenshot 2023-04-20 at 21 12 46](https://user-images.githubusercontent.com/500826/233466878-dba900cd-2111-450a-849b-a564ef676ffb.png)

I've confirmed in the logs that the data present in the bubble chart is the correct data.

Looking at recent changes I noticed this regression was introduced in https://github.com/sidekiq/sidekiq/pull/5868 while trying to improve the order in the tooltip for the bubbles chart.

After applying the fix we can verify we get the expected graphs:

![Screenshot 2023-04-20 at 21 13 12](https://user-images.githubusercontent.com/500826/233468191-59a43bd4-400e-463c-a591-add2288aef95.png)

I've opted to do the change inside the view since that is the smallest change to fix this issue. @adamlogic Let me know if you have suggestions on how to address the issue.

Thank you @adamlogic and @mperham for the awesome metrics dashboard 💚