### PR TITLE
Support multiple current attributes in middleware

### DIFF
--- a/test/current_attributes_test.rb
+++ b/test/current_attributes_test.rb
@@ -8,6 +8,10 @@ module Myapp
   class Current < ActiveSupport::CurrentAttributes
     attribute :user_id
   end
+
+  class OtherCurrent < ActiveSupport::CurrentAttributes
+    attribute :other_id
+  end
 end
 
 describe "Current attributes" do
@@ -16,36 +20,50 @@ describe "Current attributes" do
   end
 
   it "saves" do
-    cm = Sidekiq::CurrentAttributes::Save.new("Myapp::Current")
+    cm = Sidekiq::CurrentAttributes::Save.new({
+      "cattr" => "Myapp::Current",
+      "cattr_1" => "Myapp::OtherCurrent"
+    })
     job = {}
-    with_context(:user_id, 123) do
-      cm.call(nil, job, nil, nil) do
-        assert_equal 123, job["cattr"][:user_id]
+    with_context("Myapp::Current", :user_id, 123) do
+      with_context("Myapp::OtherCurrent", :other_id, 789) do
+        cm.call(nil, job, nil, nil) do
+          assert_equal 123, job["cattr"][:user_id]
+          assert_equal 789, job["cattr_1"][:other_id]
+        end
       end
     end
 
-    with_context(:user_id, 456) do
-      cm.call(nil, job, nil, nil) do
-        assert_equal 123, job["cattr"][:user_id]
+    with_context("Myapp::Current", :user_id, 456) do
+      with_context("Myapp::OtherCurrent", :other_id, 999) do
+        cm.call(nil, job, nil, nil) do
+          assert_equal 123, job["cattr"][:user_id]
+          assert_equal 789, job["cattr_1"][:other_id]
+        end
       end
     end
   end
 
   it "loads" do
-    cm = Sidekiq::CurrentAttributes::Load.new("Myapp::Current")
+    cm = Sidekiq::CurrentAttributes::Load.new({
+      "cattr" => "Myapp::Current",
+      "cattr_1" => "Myapp::OtherCurrent"
+    })
 
-    job = {"cattr" => {"user_id" => 123}}
+    job = {"cattr" => {"user_id" => 123}, "cattr_1" => {"other_id" => 456}}
     assert_nil Myapp::Current.user_id
+    assert_nil Myapp::OtherCurrent.other_id
     cm.call(nil, job, nil) do
       assert_equal 123, Myapp::Current.user_id
+      assert_equal 456, Myapp::OtherCurrent.other_id
     end
     # the Rails reloader is responsible for reseting Current after every unit of work
   end
 
-  it "persists" do
+  it "persists with class argument" do
     Sidekiq::CurrentAttributes.persist("Myapp::Current", @config)
     job_hash = {}
-    with_context(:user_id, 16) do
+    with_context("Myapp::Current", :user_id, 16) do
       @config.client_middleware.invoke(nil, job_hash, nil, nil) do
         assert_equal 16, job_hash["cattr"][:user_id]
       end
@@ -62,12 +80,27 @@ describe "Current attributes" do
     #   Sidekiq.server_middleware.clear
   end
 
+  it "persists with hash argument" do
+    cattrs = [Myapp::Current, "Myapp::OtherCurrent"]
+    Sidekiq::CurrentAttributes.persist(cattrs, @config)
+    job_hash = {}
+    with_context("Myapp::Current", :user_id, 16) do
+      with_context("Myapp::OtherCurrent", :other_id, 17) do
+        @config.client_middleware.invoke(nil, job_hash, nil, nil) do
+          assert_equal 16, job_hash["cattr"][:user_id]
+          assert_equal 17, job_hash["cattr_1"][:other_id]
+        end
+      end
+    end
+  end
+
   private
 
-  def with_context(attr, value)
-    Myapp::Current.send("#{attr}=", value)
+  def with_context(strklass, attr, value)
+    constklass = strklass.constantize
+    constklass.send("#{attr}=", value)
     yield
   ensure
-    Myapp::Current.reset_all
+    constklass.reset_all
   end
 end


### PR DESCRIPTION
Currently, when calling `Sidekiq::CurrentAttributes.persist(...)` for multiple current attributes, the middleware doesn't correctly load the serialized data in the server middleware. In fact, it fails because the attributes from the first current attribute are used for "rehydrating" the second one.

The backwards compatible solution in this PR allows for a hash argument to be passed to the aforementioned method, with a key that is used in the `jobs` hash.

```ruby
Sidekiq::CurrentAttributes.persist({
  cattr: "Myapp::Current",
  cattr_other: "Myapp::OtherCurrent"
})
```