### PR TITLE
Use LINDEX for consistent performance when calculating queue latency

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -92,11 +92,11 @@ module Sidekiq
           pipeline.zcard("retry")
           pipeline.zcard("dead")
           pipeline.scard("processes")
-          pipeline.lrange("queue:default", -1, -1)
+          pipeline.lindex("queue:default", -1)
         end
       }
 
-      default_queue_latency = if (entry = pipe1_res[6].first)
+      default_queue_latency = if (entry = pipe1_res[6])
         job = begin
           Sidekiq.load_json(entry)
         rescue
@@ -264,8 +264,8 @@ module Sidekiq
     # @return [Float] in seconds
     def latency
       entry = Sidekiq.redis { |conn|
-        conn.lrange(@rname, -1, -1)
-      }.first
+        conn.lindex(@rname, -1)
+      }
       return 0 unless entry
       job = Sidekiq.load_json(entry)
       now = Time.now.to_f


### PR DESCRIPTION
Noticed high CPU usage in Redis when aggressively calculating queue latency for large queues (1M+ jobs). According to Redis docs on LRANGE:
> Time complexity: O(S+N) where S is the distance of start offset from HEAD for small lists, from nearest end (HEAD or TAIL) for large lists; and N is the number of elements in the specified range.

However, the above is only true for Redis >= 7.0. On versions 4 to 6, it doesn't find the nearest end so using offset -1 means it goes through the entire list. Benchmarks below:

```
Redis 4 => 4.0.14
Redis 5 => 5.0.14
Redis 6 => 6.2.12
Redis 7 => 7.0.11
Warming up --------------------------------------
Redis 4 | LRANGE | S     1.556k i/100ms
Redis 5 | LRANGE | S     1.442k i/100ms
Redis 6 | LRANGE | S     1.582k i/100ms
Redis 7 | LRANGE | S     1.439k i/100ms
Redis 4 | LRANGE | L   791.000  i/100ms
Redis 5 | LRANGE | L   722.000  i/100ms
Redis 6 | LRANGE | L   700.000  i/100ms
Redis 7 | LRANGE | L     1.529k i/100ms
Redis 4 | LINDEX | S     1.290k i/100ms
Redis 5 | LINDEX | S     1.602k i/100ms
Redis 6 | LINDEX | S     1.756k i/100ms
Redis 7 | LINDEX | S     1.407k i/100ms
Redis 4 | LINDEX | L     1.568k i/100ms
Redis 5 | LINDEX | L     1.421k i/100ms
Redis 6 | LINDEX | L     1.507k i/100ms
Redis 7 | LINDEX | L     1.666k i/100ms
Calculating -------------------------------------
Redis 4 | LRANGE | S     16.978k (±20.3%) i/s -     82.468k in   5.002532s
Redis 5 | LRANGE | S     17.161k (±22.7%) i/s -     83.636k in   5.042393s
Redis 6 | LRANGE | S     18.930k (±38.9%) i/s -     87.010k in   5.010305s
Redis 7 | LRANGE | S     17.072k (±29.2%) i/s -     82.023k in   5.008211s
Redis 4 | LRANGE | L      6.413k (±11.9%) i/s -     31.640k in   5.019977s
Redis 5 | LRANGE | L      7.230k (± 8.0%) i/s -     36.100k in   5.037950s
Redis 6 | LRANGE | L      7.277k (± 8.7%) i/s -     36.400k in   5.033923s
Redis 7 | LRANGE | L     16.599k (±19.4%) i/s -     81.037k in   5.047527s
Redis 4 | LINDEX | S     17.726k (±25.9%) i/s -     86.430k in   5.075110s
Redis 5 | LINDEX | S     19.533k (±40.5%) i/s -     89.712k in   5.021008s
Redis 6 | LINDEX | S     17.187k (±16.5%) i/s -     84.288k in   5.007803s
Redis 7 | LINDEX | S     17.291k (±24.4%) i/s -     84.420k in   5.067395s
Redis 4 | LINDEX | L     17.479k (±20.5%) i/s -     84.672k in   5.005591s
Redis 5 | LINDEX | L     17.665k (±20.6%) i/s -     86.681k in   5.054898s
Redis 6 | LINDEX | L     20.567k (±46.8%) i/s -     91.927k in   5.075202s
Redis 7 | LINDEX | L     17.237k (±16.4%) i/s -     84.966k in   5.033973s

Comparison:
Redis 6 | LINDEX | L:    20566.5 i/s
Redis 5 | LINDEX | S:    19533.0 i/s - same-ish: difference falls within error
Redis 6 | LRANGE | S:    18929.8 i/s - same-ish: difference falls within error
Redis 4 | LINDEX | S:    17725.9 i/s - same-ish: difference falls within error
Redis 5 | LINDEX | L:    17665.5 i/s - same-ish: difference falls within error
Redis 4 | LINDEX | L:    17478.9 i/s - same-ish: difference falls within error
Redis 7 | LINDEX | S:    17291.1 i/s - same-ish: difference falls within error
Redis 7 | LINDEX | L:    17237.2 i/s - same-ish: difference falls within error
Redis 6 | LINDEX | S:    17187.0 i/s - same-ish: difference falls within error
Redis 5 | LRANGE | S:    17161.2 i/s - same-ish: difference falls within error
Redis 7 | LRANGE | S:    17071.6 i/s - same-ish: difference falls within error
Redis 4 | LRANGE | S:    16978.4 i/s - same-ish: difference falls within error
Redis 7 | LRANGE | L:    16599.2 i/s - same-ish: difference falls within error
Redis 6 | LRANGE | L:     7277.3 i/s - 2.83x  slower
Redis 5 | LRANGE | L:     7229.5 i/s - 2.84x  slower
Redis 4 | LRANGE | L:     6413.1 i/s - 3.21x  slower
```

Note: `S` and `L` represent queue size, 10K and 2M elements respectively.

This PR aims to make queue latency calculation performance consistent regardless of which Redis version is used by using LINDEX to fetch the queue's last element instead of LRANGE.