### PR TITLE
Accept more enqueuing options for `Job.perform_bulk`

### DIFF
--- a/lib/sidekiq/job.rb
+++ b/lib/sidekiq/job.rb
@@ -237,9 +237,9 @@ module Sidekiq
       end
       alias_method :perform_sync, :perform_inline
 
-      def perform_bulk(args, batch_size: 1_000)
+      def perform_bulk(args, **kwargs)
         client = @klass.build_client
-        client.push_bulk(@opts.merge("class" => @klass, "args" => args, :batch_size => batch_size))
+        client.push_bulk(@opts.merge(kwargs, "class" => @klass, "args" => args))
       end
 
       # +interval+ must be a timestamp, numeric or something that acts

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -413,6 +413,15 @@ describe Sidekiq::Client do
         assert_equal 1_001, jids.size
       end
 
+      it "pushes jobs into custom queue" do
+        q = Sidekiq::Queue.new("foo")
+        assert_equal 0, q.size
+
+        jids = MyJob.perform_bulk([[1], [2], [3]], "queue" => "foo")
+        assert_equal 3, jids.size
+        assert_equal 3, q.size
+      end
+
       it "handles no jobs" do
         jids = MyJob.perform_bulk([])
         assert_equal 0, jids.size


### PR DESCRIPTION
It was not possible to use `perform_bulk`, when for example, you wanted to enqueue into the custom queue or specify some delay.

Now it is possible:
```ruby
MyJob.perform_bulk([[1], [2], [3]], "queue" => "other_queue")
```