### PR TITLE
Make error handlers processing Exception prone

### DIFF
--- a/lib/sidekiq/config.rb
+++ b/lib/sidekiq/config.rb
@@ -267,7 +267,7 @@ module Sidekiq
       ctx[:_config] = self
       @options[:error_handlers].each do |handler|
         handler.call(ex, ctx)
-      rescue => e
+      rescue Exception => e
         l = logger
         l.error "!!! ERROR HANDLER THREW AN ERROR !!!"
         l.error e


### PR DESCRIPTION
A follow up to #5943 and #5920.

As @stevenharman suggested in the [comment](https://github.com/sidekiq/sidekiq/issues/5920#issuecomment-1552296080) I think that we should be super safe calling `@options[:error_handlers]` cause they can raise anything. After this change, if anything like #5920 comes up again it should be clearly visible in the logs, saving people debugging time.