### PR TITLE
Enhance metrics tab

### DIFF
--- a/lib/sidekiq/metrics/query.rb
+++ b/lib/sidekiq/metrics/query.rb
@@ -20,7 +20,7 @@ module Sidekiq
       end
 
       # Get metric data for all jobs from the last hour
-      def top_jobs(minutes: 60)
+      def top_jobs(minutes: 60, substr: nil)
         result = Result.new
 
         time = @time
@@ -35,10 +35,12 @@ module Sidekiq
           end
         end
 
+        rx = /#{Regexp.escape(substr)}/i if substr
         time = @time
         redis_results.each do |hash|
           hash.each do |k, v|
             kls, metric = k.split("|")
+            next if rx && !kls.match?(rx)
             result.job_results[kls].add_metric metric, time, v.to_i
           end
           time -= 60

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -79,4 +79,4 @@
   </table>
 </div>
 
-<p><small>Data from <%= @query_result.starts_at %> to <%= @query_result.ends_at %></small></p>
+<p><small>Data from <%= @query_result.starts_at %> to <%= @query_result.ends_at %>. Showing <%= job_results.count %> of <%= @query_result.job_results.count %> in this time period.</small></p>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -8,6 +8,7 @@
     <h1><%= t('Metrics') %></h1>
 
     <a target="blank" href="https://github.com/sidekiq/sidekiq/wiki/Metrics"><span class="info-circle" title="Click to learn more about metrics">?</span></a>
+    <%= filtering('metrics') %>
   </div>
 
   <%= erb :_metrics_period_select, locals: { periods: @periods, period: @period, path: "#{root_path}metrics" } %>


### PR DESCRIPTION
As discussed yesterday in https://github.com/sidekiq/sidekiq/issues/5974

I can't test the use of the `filtering` hook locally but I referenced the Scheduled and Retries tabs. It might look funny because of dropdown menu for selecting the time period, though?

I also looked into paginating the same way that those tabs do but the Metrics query looked different from how `Sidekiq::Paginator` works so I dropped that.

<img width="882" alt="Screenshot 2023-07-18 at 11 19 46 AM" src="https://github.com/sidekiq/sidekiq/assets/3782112/e4204631-a305-442c-84e1-9cf5ffe0f67e">
