### PR TITLE
Run CI with Redis 6 and 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,6 @@ jobs:
     - name: Set up Redis ${{ matrix.redis }}
       uses: supercharge/redis-github-action@1.5.0
       with:
-        redis-version: ${{ matrix.redis-version }}        
+        redis-version: ${{ matrix.redis }}        
     - name: Run tests
       run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,30 +13,28 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    
+    # on-hover of the checkmark, show "Ruby 3 / Redis 6" instead of "(3 / 6)"
+    name: "Ruby ${{ matrix.ruby }} / Redis ${{ matrix.redis }}"
 
     strategy:
       fail-fast: false
       matrix:
         ruby: ["2.7", "3.0", "3.1", "3.2"]
-    services:
-      redis:
-        image: redis:6.2
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 6379:6379
+        redis: [6, 7]
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Ruby
+    - name: Set up Ruby ${{ matrix.ruby }}
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true # 'bundle install' and cache gems
         ruby-version: ${{ matrix.ruby }}
+    - name: Set up Redis ${{ matrix.redis }}
+      uses: supercharge/redis-github-action@1.5.0
+      with:
+        redis-version: ${{ matrix.redis-version }}        
     - name: Run tests
       run: bundle exec rake


### PR DESCRIPTION
Redis 7 was released about 1 year ago, and it's already available on, e.g. AWS Elasticache.

I'd feel more confident upgrading (or launching new apps) to Redis 7 when Sidekiq would run CI against this version. Sidekiq is an integral part of all the apps I'm working on :-)

Redis 7 has a few breaking changes; see https://raw.githubusercontent.com/redis/redis/7.0/00-RELEASENOTES



-- Thanks for maintaining and open-souring Sidekiq 🙇 