### PR TITLE
Fix Minitest constant name in tests

### DIFF
--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -484,7 +484,7 @@ describe Sidekiq::Client do
 
   describe "sharding" do
     it "allows sidekiq_options to point to different Redi" do
-      conn = MiniTest::Mock.new
+      conn = Minitest::Mock.new
       conn.expect(:pipelined, [0, 1])
       DJob.sidekiq_options("pool" => ConnectionPool.new(size: 1) { conn })
       DJob.perform_async(1, 2, 3)
@@ -492,7 +492,7 @@ describe Sidekiq::Client do
     end
 
     it "allows #via to point to same Redi" do
-      conn = MiniTest::Mock.new
+      conn = Minitest::Mock.new
       conn.expect(:pipelined, [0, 1])
       sharded_pool = ConnectionPool.new(size: 1) { conn }
       Sidekiq::Client.via(sharded_pool) do
@@ -506,11 +506,11 @@ describe Sidekiq::Client do
     it "allows #via to point to different Redi" do
       default = @client.redis_pool
 
-      moo = MiniTest::Mock.new
+      moo = Minitest::Mock.new
       moo.expect(:pipelined, [0, 1])
       beef = ConnectionPool.new(size: 1) { moo }
 
-      oink = MiniTest::Mock.new
+      oink = Minitest::Mock.new
       oink.expect(:pipelined, [0, 1])
       pork = ConnectionPool.new(size: 1) { oink }
 
@@ -529,7 +529,7 @@ describe Sidekiq::Client do
     end
 
     it "allows Resque helpers to point to different Redi" do
-      conn = MiniTest::Mock.new
+      conn = Minitest::Mock.new
       conn.expect(:pipelined, []) { |*args, &block| block.call(conn) }
       conn.expect(:zadd, 1, [String, Array])
       DJob.sidekiq_options("pool" => ConnectionPool.new(size: 1) { conn })

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -181,7 +181,7 @@ describe Sidekiq::Processor do
     let(:raise_after_yield) { false }
     let(:skip_job) { false }
     let(:worker_args) { ["myarg"] }
-    let(:work) { MiniTest::Mock.new }
+    let(:work) { Minitest::Mock.new }
 
     before do
       work.expect(:queue_name, "queue:default")

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -836,7 +836,7 @@ describe Sidekiq::Web do
   describe "Metrics" do
     describe "/metrics" do
       it "calls the Sidekiq::Metrics::Query and renders correctly" do
-        result_mock = MiniTest::Mock.new
+        result_mock = Minitest::Mock.new
         result_mock.expect(:job_results, {})
         result_mock.expect(:marks, [])
         result_mock.expect(:buckets, [])
@@ -862,7 +862,7 @@ describe Sidekiq::Web do
         job_result_mock.expect(:totals, {"s" => 1})
         3.times { job_result_mock.expect(:hist, {"FooJob" => []}) }
 
-        result_mock = MiniTest::Mock.new
+        result_mock = Minitest::Mock.new
         result_mock.expect(:job_results, {"FooJob" => job_result_mock})
         result_mock.expect(:starts_at, Time.now - 3600)
         result_mock.expect(:ends_at, Time.now)


### PR DESCRIPTION
Minitest 5.19.0  removed the "ancient MiniTest compatibility layer" that aliased `Minitest` as `MiniTest`. CI runs without a lock file so tests are failing due to this new release.

This commit fixes all usages of MiniTest to use Minitest instead.