### PR TITLE
Add support for sidekiq_retry_in and sidekiq_retries_exhausted_block for ActiveJob

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -197,7 +197,14 @@ module Sidekiq
         # sidekiq_retry_in can return two different things:
         # 1. When to retry next, as an integer of seconds
         # 2. A symbol which re-routes the job elsewhere, e.g. :discard, :kill, :default
-        jobinst&.sidekiq_retry_in_block&.call(count, exception, msg)
+        block = jobinst&.sidekiq_retry_in_block
+
+        # the sidekiq_retry_in_block can be defined in a wrapped class (ActiveJob for instance)
+        unless msg["wrapped"].nil?
+          wrapped = Object.const_get(msg["wrapped"])
+          block = wrapped.respond_to?(:sidekiq_retry_in_block) ? wrapped.sidekiq_retry_in_block : nil
+        end
+        block&.call(count, exception, msg)
       rescue Exception => e
         handle_exception(e, {context: "Failure scheduling retry using the defined `sidekiq_retry_in` in #{jobinst.class.name}, falling back to default"})
         nil
@@ -219,6 +226,12 @@ module Sidekiq
     def retries_exhausted(jobinst, msg, exception)
       begin
         block = jobinst&.sidekiq_retries_exhausted_block
+
+        # the sidekiq_retries_exhausted_block can be defined in a wrapped class (ActiveJob for instance)
+        unless msg["wrapped"].nil?
+          wrapped = Object.const_get(msg["wrapped"])
+          block = wrapped.sidekiq_retries_exhausted_block ? wrapped.respond_to?(:sidekiq_retries_exhausted_block) : nil
+        end
         block&.call(msg, exception)
       rescue => e
         handle_exception(e, {context: "Error calling retries_exhausted", job: msg})

--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -230,7 +230,7 @@ module Sidekiq
         # the sidekiq_retries_exhausted_block can be defined in a wrapped class (ActiveJob for instance)
         unless msg["wrapped"].nil?
           wrapped = Object.const_get(msg["wrapped"])
-          block = wrapped.sidekiq_retries_exhausted_block ? wrapped.respond_to?(:sidekiq_retries_exhausted_block) : nil
+          block = wrapped.respond_to?(:sidekiq_retries_exhausted_block) ? wrapped.sidekiq_retries_exhausted_block : nil
         end
         block&.call(msg, exception)
       rescue => e

--- a/test/retry_exhausted_test.rb
+++ b/test/retry_exhausted_test.rb
@@ -64,10 +64,6 @@ describe "sidekiq_retries_exhausted" do
     @old_worker ||= OldJob.new
   end
 
-  def wrapped_worker
-    @wrapped_worker ||= WrappedJob.new
-  end
-
   def handler
     @handler ||= Sidekiq::JobRetry.new(@config.default_capsule)
   end
@@ -160,7 +156,7 @@ describe "sidekiq_retries_exhausted" do
 
   it "supports wrapped jobs" do
     assert_raises RuntimeError do
-      handler.local(wrapped_worker, job("retry_count" => 0, "retry" => 1, "wrapped" => "WrappedJob"), "default") do
+      handler.local(WrappedJob.new, job("retry_count" => 0, "retry" => 1, "wrapped" => WrappedJob.to_s), "default") do
         raise "kerblammo!"
       end
     end

--- a/test/retry_exhausted_test.rb
+++ b/test/retry_exhausted_test.rb
@@ -29,6 +29,14 @@ class Foobar
   include Sidekiq::Job
 end
 
+class WrappedJob < ActiveJob::Base
+  class_attribute :exhausted_called
+
+  sidekiq_retries_exhausted do |job|
+    WrappedJob.exhausted_called = true
+  end
+end
+
 describe "sidekiq_retries_exhausted" do
   def cleanup
     [NewJob, OldJob].each do |worker_class|
@@ -36,6 +44,7 @@ describe "sidekiq_retries_exhausted" do
       worker_class.exhausted_job = nil
       worker_class.exhausted_exception = nil
     end
+    WrappedJob.exhausted_called = nil
   end
 
   before do
@@ -53,6 +62,10 @@ describe "sidekiq_retries_exhausted" do
 
   def old_worker
     @old_worker ||= OldJob.new
+  end
+
+  def wrapped_worker
+    @wrapped_worker ||= WrappedJob.new
   end
 
   def handler
@@ -143,5 +156,15 @@ describe "sidekiq_retries_exhausted" do
 
     assert exhausted_job
     assert_equal raised_error, exhausted_exception
+  end
+
+  it "supports wrapped jobs" do
+    assert_raises RuntimeError do
+      handler.local(wrapped_worker, job("retry_count" => 0, "retry" => 1, "wrapped" => "WrappedJob"), "default") do
+        raise "kerblammo!"
+      end
+    end
+
+    assert WrappedJob.exhausted_called
   end
 end

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -389,7 +389,7 @@ describe Sidekiq::JobRetry do
       end
 
       it "supports wrapped jobs" do
-        strat, count = handler.__send__(:delay_for, ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper, 2, StandardError.new, {"wrapped" => "ActiveJobRetry"})
+        strat, count = handler.__send__(:delay_for, ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper, 2, StandardError.new, {"wrapped" => ActiveJobRetry.to_s})
         assert_equal :default, strat
         assert_equal 10, count
       end

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -63,6 +63,12 @@ class ErrorJob
   end
 end
 
+class ActiveJobRetry < ActiveJob::Base
+  sidekiq_retry_in do |count|
+    10
+  end
+end
+
 describe Sidekiq::JobRetry do
   before do
     @config = reset!
@@ -380,6 +386,12 @@ describe Sidekiq::JobRetry do
           end
         end
         assert_equal 1, ds.size
+      end
+
+      it "supports wrapped jobs" do
+        strat, count = handler.__send__(:delay_for, ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper, 2, StandardError.new, {"wrapped" => "ActiveJobRetry"})
+        assert_equal :default, strat
+        assert_equal 10, count
       end
     end
 


### PR DESCRIPTION
Hello 👋 

Trying to make the `sidekiq_retries_exhausted` and `sidekiq_retry_in` works with ActiveJob.
There some issue describing this behavior: https://github.com/sidekiq/sidekiq/issues/4496, and some workaround existing (for `sidekiq_retries_exhausted`), but none (as far as I know) for `sidekiq_retry_in`.

It is also written in the Sidekiq Wiki as currently not supported: https://github.com/sidekiq/sidekiq/wiki/Active-Job#customizing-error-handling, but it would be a huge bonus for us


Open to suggestions, other idea I had was to modify the [ActiveJob Adapter](https://github.com/rails/rails/blob/main/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb) to keep it in sync and modify the Job Instance on the fly, but thought it would be better to keep the current support as much as possible inside Sidekiq. [(That what we did as a workaround in the meantime)](https://gist.github.com/pierrickouw/da5fb6bffda2b17ab50d427ade1beb83)

There might be better places aswell in Sidekiq codebase. 

Thanks!
