### PR TITLE
Docs Refactoring -> small changes

### DIFF
--- a/docs/capsule.md
+++ b/docs/capsule.md
@@ -1,3 +1,6 @@
+
+# Sidekiq 7.0 Capsules
+
 <!--toc:start-->
 - [Sidekiq 7.0 Capsules](#sidekiq-70-capsules)
 - [The Problem](#the-problem)
@@ -8,8 +11,6 @@
   - [Redis Pools](#redis-pools)
   - [Sidekiq::Component](#sidekiqcomponent)
 <!--toc:end-->
-
-# Sidekiq 7.0 Capsules
 
 Sidekiq 7.0 contains the largest internal refactoring since Sidekiq 4.0.
 This refactoring is designed to improve deployment flexibility and allow

--- a/docs/capsule.md
+++ b/docs/capsule.md
@@ -1,3 +1,14 @@
+<!--toc:start-->
+- [Sidekiq 7.0 Capsules](#sidekiq-70-capsules)
+- [The Problem](#the-problem)
+- [The Solution](#the-solution)
+  - [Sidekiq::Config](#sidekiqconfig)
+  - [Sidekiq::Capsule](#sidekiqcapsule)
+  - [Use Cases](#use-cases)
+  - [Redis Pools](#redis-pools)
+  - [Sidekiq::Component](#sidekiqcomponent)
+<!--toc:end-->
+
 # Sidekiq 7.0 Capsules
 
 Sidekiq 7.0 contains the largest internal refactoring since Sidekiq 4.0.

--- a/docs/capsule.md
+++ b/docs/capsule.md
@@ -1,6 +1,6 @@
 
 # Sidekiq 7.0 Capsules
-
+## Table of Contents
 <!--toc:start-->
 - [Sidekiq 7.0 Capsules](#sidekiq-70-capsules)
 - [The Problem](#the-problem)

--- a/docs/capsule.md
+++ b/docs/capsule.md
@@ -1,6 +1,6 @@
 
 # Sidekiq 7.0 Capsules
-## Table of Contents
+## Quick Jump
 <!--toc:start-->
 - [Sidekiq 7.0 Capsules](#sidekiq-70-capsules)
 - [The Problem](#the-problem)

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,6 +1,6 @@
 # Sidekiq Internals
 
-## Table of Contents
+## Quick Jump
 <!--toc:start-->
 - [Sidekiq Internals](#sidekiq-internals)
   - [Table of Contents](#table-of-contents)

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,8 +1,18 @@
 # Sidekiq Internals
 
+## Table of Contents
+<!--toc:start-->
+- [Sidekiq Internals](#sidekiq-internals)
+  - [Table of Contents](#table-of-contents)
+  - [bundle exec sidekiq](#bundle-exec-sidekiq)
+  - [embedded](#embedded)
+<!--toc:end-->
+
+
+
 This document explains Sidekiq 7.0 internal code structure and implementation.
 
-## bundle exec sidekiq
+## `bundle exec sidekiq`
 
 When you start a Sidekiq instance using `bundle exec sidekiq`, execution starts in `bin/sidekiq`.
 This executable creates an instance of `Sidekiq::CLI` and runs it.


### PR DESCRIPTION
Hello, this is my first time contributing to the project, to OSS in general. I was reading through the internals.md and capsule.md in the docs directory and found myself jumping from place to place as I was going to the code that the doc files referred to `lib/sidekiq/cli.rb` and the like. There was no real need to test these changes as they have no functional change other than they may help those who go back and forth between files jump to the place they were at in the given file. No worries if these changes are not viewed as necessary, just trying to help. Thanks for the feedback and your hard work for this cool project.