### PR TITLE
Add Sidekiq::Rails::Reloader#as_json.

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -21,6 +21,10 @@ module Sidekiq
         "#<Sidekiq::Rails::Reloader @app=#{@app.class.name}>"
       end
 
+      def as_json(*)
+        inspect
+      end
+
       def to_json(*)
         Sidekiq.dump_json(inspect)
       end


### PR DESCRIPTION
We ran into a `SystemStackError` in our Rails app (7.0.7) after upgrading to Sidekiq 7.1.2. We could identify the problem to be caused by logging. We're using [Semantic Logger 4.13.0](https://github.com/reidmorrison/semantic_logger) with a [JSON formatter](https://github.com/reidmorrison/semantic_logger/blob/5ff6611255d76e2ea752f7993522cb147c5bf991/lib/semantic_logger/formatters/json.rb) and a [File Appender](https://github.com/reidmorrison/semantic_logger/blob/5ff6611255d76e2ea752f7993522cb147c5bf991/lib/semantic_logger/appender/file.rb).

After upgrading to 7.1.2, the problem occurred right after booting our app. The stack trace looks as follows:

```
SemanticLogger::Appenders -- Failed to log to appender: SemanticLogger::Appender::File -- Exception: SystemStackError: stack level too deep
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:141:in to_a
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:141:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:159:in block in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:159:in map
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:159:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:141:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:159:in block in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:159:in map
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:159:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:141:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:159:in block in as_json
```

... the sequence `map/as_json/as_json/block in as_json` repeats many times. Until it changes a bit at some point:

```
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:159:in map
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:159:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:141:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:180:in block in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:179:in each
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:179:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:63:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:180:in block in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:179:in each
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:179:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:63:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:180:in block in as_json
```

... the sequence `each/as_json/as_json/block in as_json` repeats a couple of times. Until, finally:

```
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:179:in each
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:179:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:63:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:180:in block in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:179:in each
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:179:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:180:in block in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:179:in each
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:179:in as_json
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/json/encoding.rb:35:in encode
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/json/encoding.rb:22:in encode
/usr/local/bundle/gems/activesupport-7.0.5/lib/active_support/core_ext/object/json.rb:42:in to_json
/usr/local/bundle/gems/semantic_logger-4.13.0/lib/semantic_logger/formatters/json.rb:12:in call
/usr/local/bundle/gems/semantic_logger-4.13.0/lib/semantic_logger/appender/file.rb:188:in log
/usr/local/bundle/gems/semantic_logger-4.13.0/lib/semantic_logger/appenders.rb:31:in block in log
/usr/local/bundle/gems/semantic_logger-4.13.0/lib/semantic_logger/appenders.rb:30:in each
/usr/local/bundle/gems/semantic_logger-4.13.0/lib/semantic_logger/appenders.rb:30:in log
/usr/local/bundle/gems/semantic_logger-4.13.0/lib/semantic_logger/appender/async.rb:152:in process_messages
/usr/local/bundle/gems/semantic_logger-4.13.0/lib/semantic_logger/appender/async.rb:121:in process
/usr/local/bundle/gems/semantic_logger-4.13.0/lib/semantic_logger/appender/async.rb:77:in block in thread
```

Semantic Logger's JSON formatter simply calls `to_json` on a hash, so I suspected it to be some problem with any of the nested objects being serialized. I wrote a custom formatter to dump the objects before serializing them:

```
class CustomJson < SemanticLogger::Formatters::Raw
  def initialize(time_format: :iso_8601, time_key: :timestamp, **args)
    super(time_format: time_format, time_key: time_key, **args)
  end

  def call(log, logger)
    result = super(log, logger)
    puts "Result: #{result}"
    result.to_json
  end
end
```

This helped identifying the object causing the problems:

```
Result: {:host=>"...", :application=>"Semantic Logger", :environment=>"development", :timestamp=>"...", :level=>:debug, :level_index=>1, :pid=>25, :thread=>"...", :file=>"/usr/local/bundle/gems/sidekiq-7.1.2/lib/sidekiq/launcher.rb", :line=>40, :name=>"Sidekiq", :payload=>{:labels=>#<Set: {}>, ...,  :reloader=>#<Sidekiq::Rails::Reloader @app=OurApp::Application>, ... }}
```

The `Sidekiq::Rails::Reloader` is a part of the `payload` hash that is serialized for the JSON log message.
The logging call passing it as a payload happens when the Sidekiq instance is [started](https://github.com/sidekiq/sidekiq/blob/b4eb86f37fb27a7f6553ac90fd0002cfb8c89ddd/lib/sidekiq/launcher.rb#L40).

Now when it comes to serializing the `Reloader`, Active Support kicks in and instead of using the Reloader's ' to_json`, we end up using Active Support's [override](https://github.com/rails/rails/blob/593893c901f87b4ed205751f72df41519b4d2da3/activesupport/lib/active_support/core_ext/object/json.rb#L63), which tries serializing the instance variables, and since the instance variable is the app itself ... this seems to be the root of the recursion issue.

Since Sidekiq 7 already introduced `Sidekiq::Rails::Reloader#to_json`, adding `as_json`, too, like in the proposal, would fix our issue. Would this be feasible? Or could it cause other issues in different scenarios? Thanks in advance for your thoughts!

