### PR TITLE
Implement retry_for, fixes #6029

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,7 +8,8 @@
 - Add `sidekiq_options retry_for: 48.hours` to allow time-based retry windows [#6029]
 - Support sidekiq_retry_in and sidekiq_retries_exhausted_block in ActiveJobs (#5994)
 - Lowercase all Rack headers for Rack 3.0 [#5951]
-- Validate Sidekiq::Web page refresh delay, thanks for reporting Keegan!
+- Validate Sidekiq::Web page refresh delay to avoid potential DoS,
+  CVE-2023-26141, thanks for reporting Keegan!
 
 7.1.2
 ----------

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 7.1.3
 ----------
 
+- Add `sidekiq_options retry_for: 48.hours` to allow time-based retry windows [#6029]
 - Support sidekiq_retry_in and sidekiq_retries_exhausted_block in ActiveJobs (#5994)
 - Lowercase all Rack headers for Rack 3.0 [#5951]
 - Validate Sidekiq::Web page refresh delay, thanks for reporting Keegan!

--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -66,6 +66,7 @@ module Sidekiq
     #   args - an array of simple arguments to the perform method, must be JSON-serializable
     #   at - timestamp to schedule the job (optional), must be Numeric (e.g. Time.now.to_f)
     #   retry - whether to retry this job if it fails, default true or an integer number of retries
+    #   retry_for - relative amount of time to retry this job if it fails, default nil
     #   backtrace - whether to save any error backtrace, default false
     #
     # If class is set to the class name, the jobs' options will be based on Sidekiq's default

--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -170,8 +170,10 @@ module Sidekiq
         msg["error_backtrace"] = compress_backtrace(lines)
       end
 
-      # Goodbye dear message, you (re)tried your best I'm sure.
       return retries_exhausted(jobinst, msg, exception) if count >= max_retry_attempts
+
+      rf = msg["retry_for"]
+      return retries_exhausted(jobinst, msg, exception) if rf && ((msg["failed_at"] + rf) < Time.now.to_f)
 
       strategy, delay = delay_for(jobinst, count, exception, msg)
       case strategy

--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -13,7 +13,7 @@ module Sidekiq
       raise(ArgumentError, "Job class must be either a Class or String representation of the class name: `#{item}`") unless item["class"].is_a?(Class) || item["class"].is_a?(String)
       raise(ArgumentError, "Job 'at' must be a Numeric timestamp: `#{item}`") if item.key?("at") && !item["at"].is_a?(Numeric)
       raise(ArgumentError, "Job tags must be an Array: `#{item}`") if item["tags"] && !item["tags"].is_a?(Array)
-      raise(ArgumentError, "retry_for must be a relative amount of time: 48.hours `#{item}`") if item["retry_for"] && item["retry_for"] > 1_000_000_000
+      raise(ArgumentError, "retry_for must be a relative amount of time, e.g. 48.hours `#{item}`") if item["retry_for"] && item["retry_for"] > 1_000_000_000
     end
 
     def verify_json(item)

--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -13,6 +13,7 @@ module Sidekiq
       raise(ArgumentError, "Job class must be either a Class or String representation of the class name: `#{item}`") unless item["class"].is_a?(Class) || item["class"].is_a?(String)
       raise(ArgumentError, "Job 'at' must be a Numeric timestamp: `#{item}`") if item.key?("at") && !item["at"].is_a?(Numeric)
       raise(ArgumentError, "Job tags must be an Array: `#{item}`") if item["tags"] && !item["tags"].is_a?(Array)
+      raise(ArgumentError, "retry_for must be a relative amount of time: 48.hours `#{item}`") if item["retry_for"] && item["retry_for"] > 1_000_000_000
     end
 
     def verify_json(item)
@@ -54,6 +55,7 @@ module Sidekiq
       item["jid"] ||= SecureRandom.hex(12)
       item["class"] = item["class"].to_s
       item["queue"] = item["queue"].to_s
+      item["retry_for"] = item["retry_for"].to_i
       item["created_at"] ||= Time.now.to_f
       item
     end


### PR DESCRIPTION
Allow time-based retry windows `sidekiq_options retry_for: 3.days` rather than the existing `retry` count. `retry_for` provides a simpler mental model for long a job will retry, and so can be a little more developer friendly. The drawback is that you don't have any sense for how many times Sidekiq will retry during that window.

One impl detail: existing `retry` values still have effect. If you say `retry: 1, retry_for: 1.year`, your job will still quickly die because you're only allowing one retry. The default `retry` count of 25 will last for approximately three weeks. If you want to `retry_for` longer than that, you will also need to increase the `retry` value.