### PR TITLE
Update namespace error message

### DIFF
--- a/lib/sidekiq/redis_client_adapter.rb
+++ b/lib/sidekiq/redis_client_adapter.rb
@@ -63,8 +63,7 @@ module Sidekiq
       opts = options.dup
 
       if opts[:namespace]
-        raise ArgumentError, "Your Redis configuration uses the namespace '#{opts[:namespace]}' but this feature isn't supported by redis-client. " \
-          "Either use the redis adapter or remove the namespace."
+        raise ArgumentError, "Your Redis configuration uses the namespace '#{opts[:namespace]}' but this feature isn't supported."
       end
 
       opts.delete(:size)


### PR DESCRIPTION
The error message here is now misleading, since namespaces are no longer supported.

See https://github.com/sidekiq/sidekiq/discussions/6038

I'm not sure if the message should elaborate more. I feel like just a "remove the namespace" instruction could mislead someone into doing something that appears to work at first but breaks later (e.g., dev and test sharing a Redis database). And I think to clarify that, it would take either a very wordy error message or an external link. I'm personally a fan of both of those, but that doesn't seem to match the existing Sidekiq error-reporting conventions, so I went with something simpler for now.