### PR TITLE
Adds test and documents capsule configuration through the configuration file

### DIFF
--- a/docs/capsule.md
+++ b/docs/capsule.md
@@ -59,6 +59,16 @@ Sidekiq.configure_server do |config|
 end
 ```
 
+or through the configuration file:
+```yaml
+---
+:capsules:
+  :single_thread:
+    :concurrency: 1
+    :queues:
+      - single
+```
+
 Capsules can have their own customized middleware chains but by default will inherit the global middleware configuration. Each Capsule will have its own Redis connection pool sized to the configured concurrency.
 
 `Sidekiq::Launcher` is the top-level component which takes a `Sidekiq::Config` and launches the

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -155,6 +155,11 @@ describe Sidekiq::CLI do
           assert_equal 50, concurrency
           assert_equal 2, queues.count { |q| q == "very_often" }
           assert_equal 1, queues.count { |q| q == "seldom" }
+          assert_equal 'test_capsule', capsules['test_capsule'].name
+          assert_equal 2, capsules['test_capsule'].concurrency
+          assert_equal 1, capsules['test_capsule'].queues.count { |q| q == 'capsule_queue1' }
+          assert_equal 1, capsules['test_capsule'].queues.count { |q| q == 'capsule_queue2' }
+
         end
 
         it "accepts stringy keys" do

--- a/test/config.yml
+++ b/test/config.yml
@@ -5,3 +5,9 @@
 :queues:
   - [<%="very_"%>often, 2]
   - [seldom, 1]
+:capsules:
+  :test_capsule:
+    :concurrency:  2
+    :queues:
+      - capsule_queue1
+      - capsule_queue2


### PR DESCRIPTION
It's possible to configure capsules through the configuration file, but this feature nowhere in the documentation.
Documents and tests feature already implemented.