### PR TITLE
Fix false-positive DEPRECATION message when the error_handler is non-lambda proc

### DIFF
--- a/lib/sidekiq/config.rb
+++ b/lib/sidekiq/config.rb
@@ -258,9 +258,9 @@ module Sidekiq
       @logger = logger
     end
 
-    private def arity(handler)
-      return handler.arity if handler.is_a?(Proc)
-      handler.method(:call).arity
+    private def parameter_size(handler)
+      target = handler.is_a?(Proc) ? handler : handler.method(:call)
+      target.parameters.size
     end
 
     # INTERNAL USE ONLY
@@ -269,7 +269,7 @@ module Sidekiq
         p ["!!!!!", ex]
       end
       @options[:error_handlers].each do |handler|
-        if arity(handler) == 2
+        if parameter_size(handler) == 2
           # TODO Remove in 8.0
           logger.info { "DEPRECATION: Sidekiq exception handlers now take three arguments, see #{handler}" }
           handler.call(ex, {_config: self}.merge(ctx))


### PR DESCRIPTION
When the error_handler is like `proc { |_ex, _ctx, _cfg = nil| }`, false-positive DEPRECATION message was shown (#6051).

This is because arity of lambda and non-lambda proc differs as below:

```
proc_handler = proc { |x, y, z = nil| }
proc_handler.arity #=> 2
proc_handler.parameters.size #=> 3

lambda_handler = lambda { |x, y, z = nil| }
lambda_handler.arity #=> -3
lambda_handler.parameters.size #=> 3
```

I changed the code to use `#parameters.size` instead of `#arity` for ~~proc~~ all error_handler.

---

non-lambda-proc error_handler is used in bugsnag integrations for example.

https://github.com/bugsnag/bugsnag-ruby/blob/bdfbf3972f2137b3b9b95194a6bedf9c8edf6555/lib/bugsnag/integrations/sidekiq.rb#L53
