### PR TITLE
Remove inline JS from pages

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,11 @@
 
 [Sidekiq Changes](https://github.com/sidekiq/sidekiq/blob/main/Changes.md) | [Sidekiq Pro Changes](https://github.com/sidekiq/sidekiq/blob/main/Pro-Changes.md) | [Sidekiq Enterprise Changes](https://github.com/sidekiq/sidekiq/blob/main/Ent-Changes.md)
 
+HEAD
+----------
+
+- Forbid inline JavaScript execution in Web UI [#6074]
+
 7.1.6
 ----------
 

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -15,7 +15,7 @@ module Sidekiq
       "manifest-src 'self'",
       "media-src 'self'",
       "object-src 'none'",
-      "script-src 'self' https: http: 'unsafe-inline'",
+      "script-src 'self' https: http:",
       "style-src 'self' https: http: 'unsafe-inline'",
       "worker-src 'self'",
       "base-uri 'self'"

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -60,7 +60,7 @@ describe Sidekiq::Web do
     policies = last_response.headers["Content-Security-Policy"].split("; ")
     assert_includes(policies, "connect-src 'self' https: http: wss: ws:")
     assert_includes(policies, "style-src 'self' https: http: 'unsafe-inline'")
-    assert_includes(policies, "script-src 'self' https: http: 'unsafe-inline'")
+    assert_includes(policies, "script-src 'self' https: http:")
     assert_includes(policies, "object-src 'none'")
   end
 

--- a/web/assets/javascripts/dashboard-charts.js
+++ b/web/assets/javascripts/dashboard-charts.js
@@ -166,3 +166,16 @@ class RealtimeChart extends DashboardChart {
     };
   }
 }
+
+  var rc = document.getElementById("realtime-chart")
+  if (rc != null) {
+    var rtc = new RealtimeChart(rc, JSON.parse(rc.textContent))
+    rtc.registerLegend(document.getElementById("realtime-legend"))
+    window.realtimeChart = rtc
+  }
+
+  var hc = document.getElementById("history-chart")
+  if (hc != null) {
+    var htc = new DashboardChart(hc, JSON.parse(hc.textContent))
+    window.historyChart = htc
+  }

--- a/web/assets/javascripts/metrics.js
+++ b/web/assets/javascripts/metrics.js
@@ -262,3 +262,24 @@ class HistBubbleChart extends BaseChart {
     };
   }
 }
+
+var ch = document.getElementById("job-metrics-overview-chart");
+if (ch != null) {
+  var jm = new JobMetricsOverviewChart(ch, JSON.parse(ch.textContent));
+  document.querySelectorAll(".metrics-swatch-wrapper > input[type=checkbox]").forEach((imp) => {
+    jm.registerSwatch(imp.id)
+  });
+  window.jobMetricsChart = jm;
+}
+
+var htc = document.getElementById("hist-totals-chart");
+if (htc != null) {
+  var tc = new HistTotalsChart(htc, JSON.parse(htc.textContent));
+  window.histTotalsChart = tc
+}
+
+var hbc = document.getElementById("hist-bubble-chart");
+if (hbc != null) {
+  var bc = new HistBubbleChart(hbc, JSON.parse(hbc.textContent));
+  window.histBubbleChart = bc
+}

--- a/web/views/dashboard.erb
+++ b/web/views/dashboard.erb
@@ -1,7 +1,3 @@
-<script type="text/javascript" src="<%= root_path %>javascripts/chart.min.js"></script>
-<script type="text/javascript" src="<%= root_path %>javascripts/chartjs-plugin-annotation.min.js"></script>
-<script type="text/javascript" src="<%= root_path %>javascripts/base-charts.js"></script>
-<script type="text/javascript" src="<%= root_path %>javascripts/dashboard-charts.js"></script>
 <script type="text/javascript" src="<%= root_path %>javascripts/dashboard.js"></script>
 <div class= "dashboard clearfix">
   <h3 >
@@ -20,26 +16,19 @@
 </div>
 
 <div class="row chart">
-  <canvas id="realtime-chart"></canvas>
-  <script>
-    window.realtimeChart = new RealtimeChart(
-      document.getElementById("realtime-chart"),
-      <%= Sidekiq.dump_json({
-        processedLabel: t('Processed'),
-        failedLabel: t('Failed'),
-        labels: Array.new(50, ""),
-        processed: Array.new(50),
-        failed: Array.new(50),
-        updateUrl: "#{root_path}stats",
-      }) %>
-    )
-  </script>
+  <canvas id="realtime-chart">
+    <%= Sidekiq.dump_json({
+      processedLabel: t('Processed'),
+      failedLabel: t('Failed'),
+      labels: Array.new(50, ""),
+      processed: Array.new(50),
+      failed: Array.new(50),
+      updateUrl: "#{root_path}stats",
+    }) %>
+  </canvas>
 
   <!-- start with a space in the legend so the height doesn't change when we add content dynamically -->
   <div id="realtime-legend">&nbsp;</div>
-  <script>
-    realtimeChart.registerLegend(document.getElementById("realtime-legend"))
-  </script>
 </div>
 
 <div class="row header">
@@ -55,18 +44,14 @@
     <a href="<%= root_path %>?days=180" class="history-graph <%= "active" if params[:days] == "180" %>"><%= t('SixMonths') %></a>
   </div>
 
-  <canvas id="history-chart"></canvas>
-  <script>
-    window.historyChart = new DashboardChart(
-      document.getElementById("history-chart"),
-      <%= Sidekiq.dump_json({
-        processedLabel: t('Processed'),
-        failedLabel: t('Failed'),
-        processed: @processed_history.to_a.reverse,
-        failed: @failed_history.to_a.reverse,
-      }) %>
-    )
-  </script>
+  <canvas id="history-chart">
+    <%= Sidekiq.dump_json({
+      processedLabel: t('Processed'),
+      failedLabel: t('Failed'),
+      processed: @processed_history.to_a.reverse,
+      failed: @failed_history.to_a.reverse,
+    }) %>
+  </canvas>
 </div>
 
 <br/>
@@ -113,3 +98,8 @@
     <% end %>
   </div>
 </div>
+
+<script type="text/javascript" src="<%= root_path %>javascripts/chart.min.js"></script>
+<script type="text/javascript" src="<%= root_path %>javascripts/chartjs-plugin-annotation.min.js"></script>
+<script type="text/javascript" src="<%= root_path %>javascripts/base-charts.js"></script>
+<script type="text/javascript" src="<%= root_path %>javascripts/dashboard-charts.js"></script>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -1,7 +1,6 @@
 <script type="text/javascript" src="<%= root_path %>javascripts/chart.min.js"></script>
 <script type="text/javascript" src="<%= root_path %>javascripts/chartjs-plugin-annotation.min.js"></script>
 <script type="text/javascript" src="<%= root_path %>javascripts/base-charts.js"></script>
-<script type="text/javascript" src="<%= root_path %>javascripts/metrics.js"></script>
 
 <div class="header-container">
   <div class="page-title-container">
@@ -21,22 +20,17 @@
 %>
 
 <% if job_results.any? %>
-  <canvas id="job-metrics-overview-chart"></canvas>
-
-  <script>
-    window.jobMetricsChart = new JobMetricsOverviewChart(
-      document.getElementById("job-metrics-overview-chart"),
-      <%= Sidekiq.dump_json({
-        series: job_results.map { |(kls, jr)| [kls, jr.dig("series", "s")] }.to_h,
-        marks: @query_result.marks.map { |m| [m.bucket, m.label] },
-        labels: @query_result.buckets,
-        visibleKls: visible_kls,
-        yLabel: t('TotalExecutionTime'),
-        units: t('Seconds').downcase,
-        markLabel: t('Deploy'),
-      }) %>
-    )
-  </script>
+  <canvas id="job-metrics-overview-chart">
+    <%= Sidekiq.dump_json({
+      series: job_results.map { |(kls, jr)| [kls, jr.dig("series", "s")] }.to_h,
+      marks: @query_result.marks.map { |m| [m.bucket, m.label] },
+      labels: @query_result.buckets,
+      visibleKls: visible_kls,
+      yLabel: t('TotalExecutionTime'),
+      units: t('Seconds').downcase,
+      markLabel: t('Deploy'),
+    }) %>
+  </canvas>
 <% end %>
 
 <div class="table_container">
@@ -64,7 +58,6 @@
                 />
                 <code><a href="<%= root_path %>metrics/<%= kls %>?period=<%= @period %>"><%= kls %></a></code>
               </div>
-              <script>jobMetricsChart.registerSwatch("<%= id %>")</script>
             </td>
             <td><%= jr.dig("totals", "p") - jr.dig("totals", "f") %></td>
             <td><%= jr.dig("totals", "f") %></td>
@@ -80,3 +73,5 @@
 </div>
 
 <p><small>Data from <%= @query_result.starts_at %> to <%= @query_result.ends_at %></small></p>
+
+<script type="text/javascript" src="<%= root_path %>javascripts/metrics.js"></script>

--- a/web/views/metrics_for_job.erb
+++ b/web/views/metrics_for_job.erb
@@ -1,7 +1,6 @@
 <script type="text/javascript" src="<%= root_path %>javascripts/chart.min.js"></script>
 <script type="text/javascript" src="<%= root_path %>javascripts/chartjs-plugin-annotation.min.js"></script>
 <script type="text/javascript" src="<%= root_path %>javascripts/base-charts.js"></script>
-<script type="text/javascript" src="<%= root_path %>javascripts/metrics.js"></script>
 
 <%
   job_result = @query_result.job_results[@name]
@@ -24,38 +23,28 @@
     <%= erb :_metrics_period_select, locals: { periods: @periods, period: @period, path: "#{root_path}metrics/#{@name}" } %>
   </div>
 
-  <canvas id="hist-totals-chart"></canvas>
+  <canvas id="hist-totals-chart">
+    <%= Sidekiq.dump_json({
+      series: hist_totals,
+      labels: bucket_labels,
+      xLabel: t('ExecutionTime'),
+      yLabel: t('Jobs'),
+      units: t('Jobs').downcase,
+    }) %>
+  </canvas>
 
-  <script>
-    window.histTotalsChart = new HistTotalsChart(
-      document.getElementById("hist-totals-chart"),
-      <%= Sidekiq.dump_json({
-        series: hist_totals,
-        labels: bucket_labels,
-        xLabel: t('ExecutionTime'),
-        yLabel: t('Jobs'),
-        units: t('Jobs').downcase,
-      }) %>
-    )
-  </script>
-
-  <canvas id="hist-bubble-chart"></canvas>
-
-  <script>
-    window.histBubbleChart = new HistBubbleChart(
-      document.getElementById("hist-bubble-chart"),
-      <%= Sidekiq.dump_json({
-        hist: job_result.hist,
-        marks: @query_result.marks.map { |m| [m.bucket, m.label] },
-        labels: @query_result.buckets,
-        histIntervals: bucket_intervals,
-        yLabel: t('ExecutionTime'),
-        markLabel: t('Deploy'),
-        yUnits: t('Seconds').downcase,
-        zUnits: t('Jobs').downcase,
-      }) %>
-    )
-  </script>
+  <canvas id="hist-bubble-chart">
+    <%= Sidekiq.dump_json({
+      hist: job_result.hist,
+      marks: @query_result.marks.map { |m| [m.bucket, m.label] },
+      labels: @query_result.buckets,
+      histIntervals: bucket_intervals,
+      yLabel: t('ExecutionTime'),
+      markLabel: t('Deploy'),
+      yUnits: t('Seconds').downcase,
+      zUnits: t('Jobs').downcase,
+    }) %>
+  </canvas>
 
   <p><small>Data from <%= @query_result.starts_at %> to <%= @query_result.ends_at %></small></p>
 <% else %>
@@ -66,3 +55,5 @@
 
   <div class="alert alert-success"><%= t('NoJobMetricsFound') %></div>
 <% end %>
+
+<script type="text/javascript" src="<%= root_path %>javascripts/metrics.js"></script>


### PR DESCRIPTION
This hardens the Web UI against any future attacks which might inject JavaScript into the page.

Fixes #5992