### PR TITLE
Allow nested Sidekiq::Testing

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -13,10 +13,10 @@ module Sidekiq
       def __set_test_mode(mode)
         if block_given?
           begin
-            self.__local_test_mode = mode
+            __local_test_mode_push(mode)
             yield
           ensure
-            self.__local_test_mode = nil
+            __local_test_mode_pop
           end
         else
           self.__global_test_mode = mode
@@ -28,11 +28,15 @@ module Sidekiq
       end
 
       def __local_test_mode
-        Thread.current[:__sidekiq_test_mode]
+        (Thread.current[:__sidekiq_test_mode] ||= []).last
       end
 
-      def __local_test_mode=(value)
-        Thread.current[:__sidekiq_test_mode] = value
+      def __local_test_mode_pop
+        Thread.current[:__sidekiq_test_mode].pop
+      end
+
+      def __local_test_mode_push(value)
+        (Thread.current[:__sidekiq_test_mode] ||= []) << value
       end
 
       def disable!(&block)

--- a/test/testing_test.rb
+++ b/test/testing_test.rb
@@ -100,6 +100,16 @@ describe "Sidekiq::Testing" do
       refute Sidekiq::Testing.fake?
     end
 
+    it "enables nested inline testing" do
+      Sidekiq::Testing.inline! do
+        assert Sidekiq::Testing.inline?
+        Sidekiq::Testing.inline! do
+          assert Sidekiq::Testing.inline?
+        end
+        assert Sidekiq::Testing.inline?
+      end
+    end
+
     it "enables inline testing in a block" do
       Sidekiq::Testing.disable!
       assert Sidekiq::Testing.disabled?


### PR DESCRIPTION
Hello!

With the upgrade from version `7.1.1` -> `7.1.6`, I started seeing failures on having nested `Sidekiq::Testing.inline!` blocks.  The `inline` status seemed to be lost after the inner block exited.  This behavior change seemed to be introduced in e9f212902185591831af514df6313f8ae2cce31a.  I've included a test that fails on `main` but passes with my change.

I'm a bit of a Ruby noob so happy for whatever stylistic changes :)