### PR TITLE
Raise exception on nested Sidekiq::Testing modes

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -5,6 +5,7 @@ require "sidekiq"
 
 module Sidekiq
   class Testing
+    class TestModeAlreadySetError < RuntimeError; end
     class << self
       attr_accessor :__global_test_mode
 
@@ -12,8 +13,11 @@ module Sidekiq
       # all threads. Calling with a block only affects the current Thread.
       def __set_test_mode(mode)
         if block_given?
+          if __local_test_mode
+            raise(TestModeAlreadySetError, "Local test mode already set")
+          end
+          self.__local_test_mode = mode
           begin
-            self.__local_test_mode = mode
             yield
           ensure
             self.__local_test_mode = nil

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -14,7 +14,7 @@ module Sidekiq
       def __set_test_mode(mode)
         if block_given?
           if __local_test_mode
-            raise(TestModeAlreadySetError, "Local test mode already set")
+            raise(TestModeAlreadySetError, "Nesting test modes not supported")
           end
           self.__local_test_mode = mode
           begin

--- a/test/testing_test.rb
+++ b/test/testing_test.rb
@@ -100,6 +100,18 @@ describe "Sidekiq::Testing" do
       refute Sidekiq::Testing.fake?
     end
 
+    it "exception on nested inline testing" do
+      Sidekiq::Testing.inline! do
+        assert Sidekiq::Testing.inline?
+        assert_raises(Sidekiq::Testing::TestModeAlreadySetError) do
+          Sidekiq::Testing.inline! do
+            # Block needed to set local test mode
+          end
+        end
+        assert Sidekiq::Testing.inline?
+      end
+    end
+
     it "enables inline testing in a block" do
       Sidekiq::Testing.disable!
       assert Sidekiq::Testing.disabled?


### PR DESCRIPTION
Hello!

With the upgrade from version `7.1.1` -> `7.1.6`, I started seeing failures on having nested `Sidekiq::Testing.inline!` blocks.  This behavior change seemed to be introduced in e9f212902185591831af514df6313f8ae2cce31a.

As discussed on #6076, I've added code to raise an exception in this situation so it doesn't silently fail. I've included a test that fails on `main` but passes with my change.

I'm a bit of a Ruby noob so happy for whatever stylistic changes :)