### PR TITLE
Metrics formatting.

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -292,25 +292,13 @@ module Sidekiq
       elsif rss_kb < 10_000_000
         "#{number_with_delimiter((rss_kb / 1024.0).to_i)} MB"
       else
-        "#{number_with_delimiter((rss_kb / (1024.0 * 1024.0)).round(1))} GB"
+        "#{number_with_delimiter((rss_kb / (1024.0 * 1024.0)), precision: 1)} GB"
       end
     end
 
     def number_with_delimiter(number, options = {})
-      return "" if number.nil?
-
-      begin
-        Float(number)
-      rescue ArgumentError, TypeError
-        return number
-      end
-
-      options = {delimiter: ",", separator: "."}.merge(options)
-      number = number.to_s.to_str
-      number = sprintf("%.#{options[:precision]}f", number) unless options[:precision].nil?
-      parts = number.split(".")
-      parts[0].gsub!(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1#{options[:delimiter]}")
-      parts.join(options[:separator])
+      precision = options[:precision] || 0
+      %(<span data-nwp="#{precision}">#{number.round(precision)}</span>)
     end
 
     def h(text)

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -296,7 +296,7 @@ module Sidekiq
       end
     end
 
-    def number_with_delimiter(number)
+    def number_with_delimiter(number, options = {})
       return "" if number.nil?
 
       begin
@@ -305,8 +305,10 @@ module Sidekiq
         return number
       end
 
-      options = {delimiter: ",", separator: "."}
-      parts = number.to_s.to_str.split(".")
+      options = {delimiter: ",", separator: "."}.merge(options)
+      number = number.to_s.to_str
+      number = sprintf("%.#{options[:precision]}f", number) unless options[:precision].nil?
+      parts = number.split(".")
       parts[0].gsub!(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1#{options[:delimiter]}")
       parts.join(options[:separator])
     end

--- a/test/web_helpers_test.rb
+++ b/test/web_helpers_test.rb
@@ -136,17 +136,17 @@ describe "Web helpers" do
   describe "#format_memory" do
     it "returns in KB" do
       obj = Helpers.new
-      assert_equal "1 KB", obj.format_memory(1)
+      assert_equal "<span data-nwp=\"0\">1</span> KB", obj.format_memory(1)
     end
 
     it "returns in MB" do
       obj = Helpers.new
-      assert_equal "97 MB", obj.format_memory(100_002)
+      assert_equal "<span data-nwp=\"0\">97</span> MB", obj.format_memory(100_002)
     end
 
     it "returns in GB" do
       obj = Helpers.new
-      assert_equal "9.5 GB", obj.format_memory(10_000_001)
+      assert_equal "<span data-nwp=\"1\">9.5</span> GB", obj.format_memory(10_000_001)
     end
   end
 

--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -33,6 +33,7 @@ function addListeners() {
 
   addShiftClickListeners()
   updateFuzzyTimes();
+  updateNumbers();
   setLivePollFromUrl();
 
   var buttons = document.querySelectorAll(".live-poll");
@@ -100,6 +101,20 @@ function updateFuzzyTimes() {
   var t = timeago()
   t.render(document.querySelectorAll('time'), locale);
   t.cancel();
+}
+
+function updateNumbers() {
+  document.querySelectorAll("[data-number-with-precision]").forEach(node => {
+    let number = parseInt(node.textContent);
+    let precision = parseInt(node.dataset["numberWithPrecision"] || 0);
+    if (typeof number === "number") {
+      let formatted = number.toLocaleString(undefined, {
+        minimumFractionDigits: precision,
+        maximumFractionDigits: precision,
+      });
+      node.textContent = formatted;
+    }
+  });
 }
 
 function setLivePollFromUrl() {

--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -104,9 +104,9 @@ function updateFuzzyTimes() {
 }
 
 function updateNumbers() {
-  document.querySelectorAll("[data-number-with-precision]").forEach(node => {
-    let number = parseInt(node.textContent);
-    let precision = parseInt(node.dataset["numberWithPrecision"] || 0);
+  document.querySelectorAll("[data-nwp]").forEach(node => {
+    let number = parseFloat(node.textContent);
+    let precision = parseInt(node.dataset["nwp"] || 0);
     if (typeof number === "number") {
       let formatted = number.toLocaleString(undefined, {
         minimumFractionDigits: precision,

--- a/web/assets/javascripts/dashboard-charts.js
+++ b/web/assets/javascripts/dashboard-charts.js
@@ -86,6 +86,7 @@ class RealtimeChart extends DashboardChart {
     updateStatsSummary(this.stats.sidekiq);
     updateRedisStats(this.stats.redis);
     updateFooterUTCTime(this.stats.server_utc_time);
+    updateNumbers();
     pulseBeacon();
 
     this.stats = stats;

--- a/web/assets/javascripts/dashboard.js
+++ b/web/assets/javascripts/dashboard.js
@@ -1,15 +1,13 @@
 Sidekiq = {};
 
-var nf = new Intl.NumberFormat();
-
 var updateStatsSummary = function(data) {
-  document.getElementById("txtProcessed").innerText = nf.format(data.processed);
-  document.getElementById("txtFailed").innerText = nf.format(data.failed);
-  document.getElementById("txtBusy").innerText = nf.format(data.busy);
-  document.getElementById("txtScheduled").innerText = nf.format(data.scheduled);
-  document.getElementById("txtRetries").innerText = nf.format(data.retries);
-  document.getElementById("txtEnqueued").innerText = nf.format(data.enqueued);
-  document.getElementById("txtDead").innerText = nf.format(data.dead);
+  document.getElementById("txtProcessed").innerText = data.processed;
+  document.getElementById("txtFailed").innerText = data.failed;
+  document.getElementById("txtBusy").innerText = data.busy;
+  document.getElementById("txtScheduled").innerText = data.scheduled;
+  document.getElementById("txtRetries").innerText = data.retries;
+  document.getElementById("txtEnqueued").innerText = data.enqueued;
+  document.getElementById("txtDead").innerText = data.dead;
 }
 
 var updateRedisStats = function(data) {

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -371,11 +371,11 @@ img.smallogo {
   font-size: 0.9em;
 }
 
-.metric {
+.num {
   font-family: monospace;
 }
 
-td.metric {
+td.num {
   text-align: right;
 }
 

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -370,6 +370,15 @@ img.smallogo {
 .stat p {
   font-size: 0.9em;
 }
+
+.metric {
+  font-family: monospace;
+}
+
+td.metric {
+  text-align: right;
+}
+
 @media (max-width: 767px) {
   .stats-container {
     display: block;

--- a/web/views/_summary.erb
+++ b/web/views/_summary.erb
@@ -1,39 +1,39 @@
 <ul class="list-unstyled summary row">
   <li class="processed col-sm-1">
-    <span id="txtProcessed" class="count"><%= number_with_delimiter(stats.processed) %></span>
+    <span id="txtProcessed" class="count" data-nwp><%= stats.processed %></span>
     <span class="desc"><%= t('Processed') %></span>
   </li>
   <li class="failed col-sm-1">
-    <span id="txtFailed" class="count"><%= number_with_delimiter(stats.failed) %></span>
+    <span id="txtFailed" class="count" data-nwp><%= stats.failed %></span>
     <span class="desc"><%= t('Failed') %></span>
   </li>
   <li class="busy col-sm-1">
     <a href="<%= root_path %>busy">
-      <span id="txtBusy" class="count"><%= number_with_delimiter(workset.size) %></span>
+      <span id="txtBusy" class="count" data-nwp><%= workset.size %></span>
       <span class="desc"><%= t('Busy') %></span>
     </a>
   </li>
   <li class="enqueued col-sm-1">
     <a href="<%= root_path %>queues">
-      <span id="txtEnqueued" class="count"><%= number_with_delimiter(stats.enqueued) %></span>
+      <span id="txtEnqueued" class="count" data-nwp><%= stats.enqueued %></span>
       <span class="desc"><%= t('Enqueued') %></span>
     </a>
   </li>
   <li class="retries col-sm-1">
     <a href="<%= root_path %>retries">
-      <span id="txtRetries" class="count"><%= number_with_delimiter(stats.retry_size) %></span>
+      <span id="txtRetries" class="count" data-nwp><%= stats.retry_size %></span>
       <span class="desc"><%= t('Retries') %></span>
     </a>
   </li>
   <li class="scheduled col-sm-1">
     <a href="<%= root_path %>scheduled">
-      <span id="txtScheduled" class="count"><%= number_with_delimiter(stats.scheduled_size) %></span>
+      <span id="txtScheduled" class="count" data-nwp><%= stats.scheduled_size %></span>
       <span class="desc"><%= t('Scheduled') %></span>
     </a>
   </li>
   <li class="dead col-sm-1">
     <a href="<%= root_path %>morgue">
-      <span id="txtDead" class="count"><%= number_with_delimiter(stats.dead_size) %></span>
+      <span id="txtDead" class="count" data-nwp><%= stats.dead_size %></span>
       <span class="desc"><%= t('Dead') %></span>
     </a>
   </li>

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -87,8 +87,8 @@
         </td>
         <td><%= relative_time(Time.at(process['started_at'])) %></td>
         <td class="metric"><%= format_memory(process['rss'].to_i) %></td>
-        <td class="metric"><%= number_with_delimeter(process['concurrency']) %></td>
-        <td class="metric"><%= number_with_delimeter(process['busy']) %></td>
+        <td class="metric"><%= number_with_delimiter(process['concurrency']) %></td>
+        <td class="metric"><%= number_with_delimiter(process['busy']) %></td>
         <td>
           <% unless process.embedded? %>
             <form method="POST">

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -86,9 +86,9 @@
           <% end %>
         </td>
         <td><%= relative_time(Time.at(process['started_at'])) %></td>
-        <td><%= format_memory(process['rss'].to_i) %></td>
-        <td><%= process['concurrency'] %></td>
-        <td><%= process['busy'] %></td>
+        <td class="metric"><%= format_memory(process['rss'].to_i) %></td>
+        <td class="metric"><%= number_with_delimeter(process['concurrency']) %></td>
+        <td class="metric"><%= number_with_delimeter(process['busy']) %></td>
         <td>
           <% unless process.embedded? %>
             <form method="POST">

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -86,9 +86,9 @@
           <% end %>
         </td>
         <td><%= relative_time(Time.at(process['started_at'])) %></td>
-        <td class="metric"><%= format_memory(process['rss'].to_i) %></td>
-        <td class="metric"><%= number_with_delimiter(process['concurrency']) %></td>
-        <td class="metric"><%= number_with_delimiter(process['busy']) %></td>
+        <td class="num"><%= format_memory(process['rss'].to_i) %></td>
+        <td class="num"><%= number_with_delimiter(process['concurrency']) %></td>
+        <td class="num"><%= number_with_delimiter(process['busy']) %></td>
         <td>
           <% unless process.embedded? %>
             <form method="POST">

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -59,10 +59,10 @@
                 <code><a href="<%= root_path %>metrics/<%= kls %>?period=<%= @period %>"><%= kls %></a></code>
               </div>
             </td>
-            <td class="metric"><%= number_with_delimiter(jr.dig("totals", "p") - jr.dig("totals", "f")) %></samp></td>
-            <td class="metric"><%= number_with_delimiter(jr.dig("totals", "f")) %></samp></td>
-            <td class="metric"><%= number_with_delimiter(jr.dig("totals", "s"), precision: 2) %></samp></td>
-            <td class="metric"><%= number_with_delimiter(jr.total_avg("s"), precision: 2) %></samp></td>
+            <td class="metric"><%= number_with_delimiter(jr.dig("totals", "p") - jr.dig("totals", "f")) %></td>
+            <td class="metric"><%= number_with_delimiter(jr.dig("totals", "f")) %></td>
+            <td class="metric"><%= number_with_delimiter(jr.dig("totals", "s"), precision: 2) %></td>
+            <td class="metric"><%= number_with_delimiter(jr.total_avg("s"), precision: 2) %></td>
           </tr>
         <% end %>
       <% else %>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -40,8 +40,8 @@
         <th><%= t('Name') %></th>
         <th><%= t('Success') %></th>
         <th><%= t('Failure') %></th>
-        <th><%= t('TotalExecutionTime') %></th>
-        <th><%= t('AvgExecutionTime') %></th>
+        <th><%= t('TotalExecutionTime') %> (Seconds)</th>
+        <th><%= t('AvgExecutionTime') %> (Seconds)</th>
       </tr>
       <% if job_results.any? %>
         <% job_results.each_with_index do |(kls, jr), i| %>
@@ -59,10 +59,10 @@
                 <code><a href="<%= root_path %>metrics/<%= kls %>?period=<%= @period %>"><%= kls %></a></code>
               </div>
             </td>
-            <td><%= jr.dig("totals", "p") - jr.dig("totals", "f") %></td>
-            <td><%= jr.dig("totals", "f") %></td>
-            <td><%= jr.dig("totals", "s").round(2) %> seconds</td>
-            <td><%= jr.total_avg("s").round(2) %> seconds</td>
+            <td align="right"><samp><%= number_with_delimiter(jr.dig("totals", "p") - jr.dig("totals", "f")) %></samp></td>
+            <td align="right"><samp><%= number_with_delimiter(jr.dig("totals", "f")) %></samp></td>
+            <td align="right"><samp><%= number_with_delimiter(jr.dig("totals", "s"), precision: 2) %></samp></td>
+            <td align="right"><samp><%= number_with_delimiter(jr.total_avg("s"), precision: 2) %></samp></td>
           </tr>
         <% end %>
       <% else %>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -59,10 +59,10 @@
                 <code><a href="<%= root_path %>metrics/<%= kls %>?period=<%= @period %>"><%= kls %></a></code>
               </div>
             </td>
-            <td align="right"><samp><%= number_with_delimiter(jr.dig("totals", "p") - jr.dig("totals", "f")) %></samp></td>
-            <td align="right"><samp><%= number_with_delimiter(jr.dig("totals", "f")) %></samp></td>
-            <td align="right"><samp><%= number_with_delimiter(jr.dig("totals", "s"), precision: 2) %></samp></td>
-            <td align="right"><samp><%= number_with_delimiter(jr.total_avg("s"), precision: 2) %></samp></td>
+            <td align="right"><samp data-number-with-precision="0"><%= jr.dig("totals", "p") - jr.dig("totals", "f") %></samp></td>
+            <td align="right"><samp data-number-with-precision="0"><%= jr.dig("totals", "f") %></samp></td>
+            <td align="right"><samp data-number-with-precision="2"><%= jr.dig("totals", "s").round(2) %></samp></td>
+            <td align="right"><samp data-number-with-precision="2"><%= jr.total_avg("s").round(2) %></samp></td>
           </tr>
         <% end %>
       <% else %>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -59,10 +59,10 @@
                 <code><a href="<%= root_path %>metrics/<%= kls %>?period=<%= @period %>"><%= kls %></a></code>
               </div>
             </td>
-            <td class="metric"><%= number_with_delimiter(jr.dig("totals", "p") - jr.dig("totals", "f")) %></td>
-            <td class="metric"><%= number_with_delimiter(jr.dig("totals", "f")) %></td>
-            <td class="metric"><%= number_with_delimiter(jr.dig("totals", "s"), precision: 2) %></td>
-            <td class="metric"><%= number_with_delimiter(jr.total_avg("s"), precision: 2) %></td>
+            <td class="num"><%= number_with_delimiter(jr.dig("totals", "p") - jr.dig("totals", "f")) %></td>
+            <td class="num"><%= number_with_delimiter(jr.dig("totals", "f")) %></td>
+            <td class="num"><%= number_with_delimiter(jr.dig("totals", "s"), precision: 2) %></td>
+            <td class="num"><%= number_with_delimiter(jr.total_avg("s"), precision: 2) %></td>
           </tr>
         <% end %>
       <% else %>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -59,10 +59,10 @@
                 <code><a href="<%= root_path %>metrics/<%= kls %>?period=<%= @period %>"><%= kls %></a></code>
               </div>
             </td>
-            <td align="right"><samp data-number-with-precision="0"><%= jr.dig("totals", "p") - jr.dig("totals", "f") %></samp></td>
-            <td align="right"><samp data-number-with-precision="0"><%= jr.dig("totals", "f") %></samp></td>
-            <td align="right"><samp data-number-with-precision="2"><%= jr.dig("totals", "s").round(2) %></samp></td>
-            <td align="right"><samp data-number-with-precision="2"><%= jr.total_avg("s").round(2) %></samp></td>
+            <td class="metric"><%= number_with_delimiter(jr.dig("totals", "p") - jr.dig("totals", "f")) %></samp></td>
+            <td class="metric"><%= number_with_delimiter(jr.dig("totals", "f")) %></samp></td>
+            <td class="metric"><%= number_with_delimiter(jr.dig("totals", "s"), precision: 2) %></samp></td>
+            <td class="metric"><%= number_with_delimiter(jr.total_avg("s"), precision: 2) %></samp></td>
           </tr>
         <% end %>
       <% else %>

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -18,8 +18,12 @@
             <span class="label label-danger"><%= t('Paused') %></span>
           <% end %>
         </td>
-        <td><%= number_with_delimiter(queue.size) %> </td>
-        <td><% queue_latency = queue.latency %><%= number_with_delimiter(queue_latency.round(2)) %><%= (queue_latency < 60) ? '' : " (#{relative_time(Time.at(Time.now.to_f - queue_latency))})" %> </td>
+        <td class="metric"><%= number_with_delimiter(queue.size) %> </td>
+        <td class="metric">
+          <% queue_latency = queue.latency %>
+          <%= (queue_latency < 60) ? '' : " (#{relative_time(Time.at(Time.now.to_f - queue_latency))})" %>
+          <%= number_with_delimiter(queue_latency.round(2)) %>
+        </td>
         <td class="delete-confirm">
           <form action="<%=root_path %>queues/<%= CGI.escape(queue.name) %>" method="post">
             <%= csrf_tag %>

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -22,7 +22,7 @@
         <td class="metric">
           <% queue_latency = queue.latency %>
           <%= (queue_latency < 60) ? '' : " (#{relative_time(Time.at(Time.now.to_f - queue_latency))})" %>
-          <%= number_with_delimiter(queue_latency.round(2)) %>
+          <%= number_with_delimiter(queue_latency, precision: 2) %>
         </td>
         <td class="delete-confirm">
           <form action="<%=root_path %>queues/<%= CGI.escape(queue.name) %>" method="post">

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -18,8 +18,8 @@
             <span class="label label-danger"><%= t('Paused') %></span>
           <% end %>
         </td>
-        <td class="metric"><%= number_with_delimiter(queue.size) %> </td>
-        <td class="metric">
+        <td class="num"><%= number_with_delimiter(queue.size) %> </td>
+        <td class="num">
           <% queue_latency = queue.latency %>
           <%= (queue_latency < 60) ? '' : " (#{relative_time(Time.at(Time.now.to_f - queue_latency))})" %>
           <%= number_with_delimiter(queue_latency, precision: 2) %>


### PR DESCRIPTION
Hi @mperham,

I finally got around to updating to Sidekiq 7, great work!

I dig the new metrics tab, but it got me thinking about numbers in tables. The idea here is to make numbers more scannable by:

- Right aligning
- Using a monospace font
- Forcing precision (i.e `1.4 -> 1.40` so everything aligns within the column)
- Adding delimiters
- Moving units to the table header

If you prefer the way this looks, I could finish up this PR by formatting every numeric column the same way.

Here's a before and after example:

![Table comparison](https://github.com/sidekiq/sidekiq/assets/133809/f510aa96-5bf8-4202-80b6-69c46d965166)

Thanks!