### PR TITLE
Support :discard return value in sidekiq_retries_exhausted block

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -226,7 +226,7 @@ module Sidekiq
     end
 
     def retries_exhausted(jobinst, msg, exception)
-      begin
+      rv = begin
         block = jobinst&.sidekiq_retries_exhausted_block
 
         # the sidekiq_retries_exhausted_block can be defined in a wrapped class (ActiveJob for instance)
@@ -239,6 +239,7 @@ module Sidekiq
         handle_exception(e, {context: "Error calling retries_exhausted", job: msg})
       end
 
+      return if rv == :discard # poof!
       send_to_morgue(msg) unless msg["dead"] == false
 
       @capsule.config.death_handlers.each do |handler|

--- a/test/retry_exhausted_test.rb
+++ b/test/retry_exhausted_test.rb
@@ -25,6 +25,17 @@ class OldJob
   end
 end
 
+class DiscardJob
+  include Sidekiq::Job
+
+  sidekiq_class_attribute :exhausted_called
+
+  sidekiq_retries_exhausted do |job, e|
+    self.exhausted_called = true
+    :discard
+  end
+end
+
 class Foobar
   include Sidekiq::Job
 end
@@ -190,6 +201,28 @@ describe "sidekiq_retries_exhausted" do
 
     assert exhausted_job
     assert exhausted_exception
+  end
+
+  it "supports discard option to disble global failure handlers and dead set" do
+    discard_job = DiscardJob.new
+
+    exhausted_job = nil
+    exhausted_exception = nil
+    @config.death_handlers.clear
+    @config.death_handlers << proc do |job, ex|
+      exhausted_job = job
+      exhausted_exception = ex
+    end
+    assert_raises RuntimeError do
+      handler.local(discard_job, job("retry" => 0), "default") do
+        raise "kerblammo!"
+      end
+    end
+
+    assert DiscardJob.exhausted_called
+    assert_equal 0, Sidekiq::DeadSet.new.size
+    assert_nil exhausted_job
+    assert_nil exhausted_exception
   end
 
   it "supports wrapped jobs" do


### PR DESCRIPTION
Provides the same functionality to `sidekiq_retries_exhausted` as `:discard` for `sidekiq_retry_in` of not sending these jobs to the dead set or calling global death handlers. This is useful for jobs that have retries disabled, which as a result means `sidekiq_retry_in` is never called.

Note: this is slightly different than the existing behavior of jobs with `dead: false`, in which case those jobs skip the dead set, but global death handlers are still called. Added tests to document/confirm that behavior, but didn't change it as part of this.