### PR TITLE
fix: reuse Sidekiq redis pool with the user defined options

### DIFF
--- a/lib/sidekiq/deploy.rb
+++ b/lib/sidekiq/deploy.rb
@@ -24,7 +24,7 @@ module Sidekiq
       Sidekiq::Deploy.new.mark!(label: label)
     end
 
-    def initialize(pool = Sidekiq::RedisConnection.create)
+    def initialize(pool = Sidekiq.redis_pool)
       @pool = pool
     end
 


### PR DESCRIPTION
If you don't reuse the Sidekiq pool you must set it up on your `sidekiq` initializer like this:

```ruby
Sidekiq::Deploy.new(Sidekiq.redis_pool).mark! IO.read("#{Rails.root}/.git_sha")
```

Otherwise, you will receive a connection error in case you do not use the default `REDIS_URL` environment config.