### PR TITLE
Use `Rails.logger.respond_to?(:broadcast_to)`  to determine if `ActiveSupport::BroadcastLogger` is available

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -56,10 +56,10 @@ module Sidekiq
         # This is the integration code necessary so that if a job uses `Rails.logger.info "Hello"`,
         # it will appear in the Sidekiq console with all of the job context.
         unless ::Rails.logger == config.logger || ::ActiveSupport::Logger.logger_outputs_to?(::Rails.logger, $stdout)
-          if ::Rails::VERSION::STRING < "7.1"
-            ::Rails.logger.extend(::ActiveSupport::Logger.broadcast(config.logger))
-          else
+          if ::Rails.logger.respond_to? :broadcast_to
             ::Rails.logger.broadcast_to(config.logger)
+          else
+            ::Rails.logger.extend(::ActiveSupport::Logger.broadcast(config.logger))
           end
         end
       end

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -56,7 +56,7 @@ module Sidekiq
         # This is the integration code necessary so that if a job uses `Rails.logger.info "Hello"`,
         # it will appear in the Sidekiq console with all of the job context.
         unless ::Rails.logger == config.logger || ::ActiveSupport::Logger.logger_outputs_to?(::Rails.logger, $stdout)
-          if ::Rails.logger.respond_to? :broadcast_to
+          if ::Rails.logger.respond_to?(:broadcast_to)
             ::Rails.logger.broadcast_to(config.logger)
           else
             ::Rails.logger.extend(::ActiveSupport::Logger.broadcast(config.logger))


### PR DESCRIPTION
I might be the only one with this problem, but here it goes: There are Rails commits (between 7.0 and 7.1) where `Rails.logger` is not yet a `ActiveSupport::BroadcastLogger`, but in these commits the `Rails::VERSION::STRING` is `7.1.0.alpha`. (For other reasons, I'm currently stuck at one of those commits). In this case sidekiq will try to use the `broadcast_to` method of the `ActiveSupport::BroadcastLogger` which it expects from a 7.1 rails version, but it's not there, so it fails. My suggestion would be to test the logger capability rather than to assume it from the version string. 