### PR TITLE
Fix Sidekiq boolean methods

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -46,7 +46,7 @@ module Sidekiq
   end
 
   def self.server?
-    defined?(Sidekiq::CLI)
+    defined?(Sidekiq::CLI) || false
   end
 
   def self.load_json(string)
@@ -58,11 +58,11 @@ module Sidekiq
   end
 
   def self.pro?
-    defined?(Sidekiq::Pro)
+    defined?(Sidekiq::Pro) || false
   end
 
   def self.ent?
-    defined?(Sidekiq::Enterprise)
+    defined?(Sidekiq::Enterprise) || false
   end
 
   def self.redis_pool


### PR DESCRIPTION
The ruby-doc documentation says that methods like `Sidekiq.server?` return a boolean, but this is not the case, because they use `defined?` under the hood. 

```ruby
foo = "bar"
defined?(foo) # => true
defined?(bar) # => nil 
```

This means on a non-Sidekiq process, `Sidekiq.server?` will return nil.

This ensures that a boolean is always returned.