### PR TITLE
Add ruby2_keywords to Sidekiq::RedisClientAdapter::CompatMethods

### DIFF
--- a/lib/sidekiq/redis_client_adapter.rb
+++ b/lib/sidekiq/redis_client_adapter.rb
@@ -35,6 +35,7 @@ module Sidekiq
         define_method(name) do |*args|
           @client.call(name, *args)
         end
+        ruby2_keywords name if respond_to?(:ruby2_keywords, true)
       end
 
       private


### PR DESCRIPTION
Hello,

Please see this small change to add ruby2_keywords to dynamically created methods in the redis_client_adapter.

This will avoid deprecation warnings such as this:
sidekiq-7.2.0/lib/sidekiq/redis_client_adapter.rb:36: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

Backtrace
```
lib/sidekiq/redis_client_adapter.rb:36 block (2 levels) in <module:CompatMethods>	
lib/sidekiq-ent/periodic/config.rb:68 block (2 levels) in persist	
lib/redis_client/decorator.rb:51 block in pipelined	
lib/redis_client.rb:371 pipelined	
lib/redis_client/decorator.rb:51 pipelined	
lib/sidekiq-ent/periodic/config.rb:66 block in persist	
lib/sidekiq/config.rb:163 block in redis	
lib/connection_pool.rb:110 block (2 levels) in with	
lib/connection_pool.rb:109 handle_interrupt	
lib/connection_pool.rb:109 block in with	
lib/connection_pool.rb:106 handle_interrupt	
lib/connection_pool.rb:106 with	
lib/sidekiq/config.rb:160 redis	
lib/sidekiq/component.rb:28 redis	
lib/sidekiq-ent/periodic/config.rb:65 persist	
lib/sidekiq-ent/periodic/manager.rb:61 persist	
lib/sidekiq-ent/periodic.rb:94 block (2 levels) in <top (required)>	
lib/sidekiq/component.rb:60 block in fire_event	
lib/sidekiq/component.rb:59 each	
lib/sidekiq/component.rb:59 fire_event	
lib/sidekiq-ent/senate.rb:88 stage_coup!	
lib/sidekiq-ent/senate.rb:135 election	
lib/sidekiq-ent/senate.rb:103 cycle	
lib/sidekiq/component.rb:10 watchdog	
lib/sidekiq/component.rb:19 block in safe_thread
```
