### PR TITLE
Add new Sidekiq::Work type

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,8 @@
 HEAD
 ----------
 
+- Add `Sidekiq::Work` type which replaces the raw Hash in
+  `Sidekiq::WorkSet#each { |pid, tid, hash| ... }` [#6145]
 - Fix Ruby 3.3 warnings around `base64` gem [#6151, earlopain]
 
 7.2.0

--- a/Changes.md
+++ b/Changes.md
@@ -5,8 +5,14 @@
 HEAD
 ----------
 
-- Add `Sidekiq::Work` type which replaces the raw Hash in
+- Add `Sidekiq::Work` type which replaces the raw Hash as the third parameter in
   `Sidekiq::WorkSet#each { |pid, tid, hash| ... }` [#6145]
+- **DEPRECATED**: direct access to the attributes within the `hash` block parameter above.
+  The `Sidekiq::Work` instance contains accessor methods to get at the same data, e.g.
+```ruby
+work["queue"] # Old
+work.queue # New
+```
 - Fix Ruby 3.3 warnings around `base64` gem [#6151, earlopain]
 
 7.2.0

--- a/Ent-Changes.md
+++ b/Ent-Changes.md
@@ -7,6 +7,8 @@ Please see [sidekiq.org](https://sidekiq.org) for more details and how to buy.
 HEAD
 ---------
 
+- Add `within_limit(used: 1)` option to `window` and `bucket` rate limiters.
+  You can adjust the number of points used by a call performing batch operations [#6146]
 - Use HWIA when scheduling periodic ActiveJobs, for compatibility [#6099]
 
 7.2.0

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -1113,7 +1113,7 @@ module Sidekiq
         end
       end
 
-      results.sort_by { |(_, _, hsh)| hsh["run_at"] }.each(&block)
+      results.sort_by { |(_, _, hsh)| hsh.raw("run_at") }.each(&block)
     end
 
     # Note that #size is only as accurate as Sidekiq's heartbeat,
@@ -1159,17 +1159,25 @@ module Sidekiq
     end
 
     def job
-      @job ||= Sidekiq.load_json(@hsh["payload"])
+      @job ||= Sidekiq::JobRecord.new(@hsh["payload"])
     end
 
     def payload
       @hsh["payload"]
     end
 
+    # deprecated
     def [](key)
-      return job if key == "payload"
+      warn("Direct access to `Sidekiq::Work` attributes is deprecated, please use `#payload`, `#queue`, `#run_at` or `#job` instead",
+        uplevel: 1, category: :deprecated)
 
       @hsh[key]
+    end
+
+    # :nodoc:
+    # @api private
+    def raw(name)
+      @hsh[name]
     end
 
     def method_missing(*all)

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -1167,6 +1167,8 @@ module Sidekiq
     end
 
     def [](key)
+      return job if key == "payload"
+
       @hsh[key]
     end
 

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -1168,8 +1168,9 @@ module Sidekiq
 
     # deprecated
     def [](key)
-      warn("Direct access to `Sidekiq::Work` attributes is deprecated, please use `#payload`, `#queue`, `#run_at` or `#job` instead",
-        uplevel: 1, category: :deprecated)
+      kwargs = {uplevel: 1}
+      kwargs[:category] = :deprecated if RUBY_VERSION > "3.0"
+      warn("Direct access to `Sidekiq::Work` attributes is deprecated, please use `#payload`, `#queue`, `#run_at` or `#job` instead", **kwargs)
 
       @hsh[key]
     end

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -638,11 +638,12 @@ describe "API" do
         assert_equal key, p
         assert_equal "1234", x
         assert_equal "default", work["queue"]
-        assert_equal("{}", work["payload"])
+        assert_equal({}, work["payload"])
         assert_equal Time.now.year, Time.at(work["run_at"]).year
 
         assert_equal "{}", work.payload
         assert_equal({}, work.job)
+        assert_equal({}, work["payload"])
         assert_equal(Time.now.year, work.run_at.year)
         assert_equal "default", work.queue
         assert_equal "1234", work.thread_id

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -638,12 +638,11 @@ describe "API" do
         assert_equal key, p
         assert_equal "1234", x
         assert_equal "default", work["queue"]
-        assert_equal({}, work["payload"])
+        assert_equal("{}", work["payload"])
         assert_equal Time.now.year, Time.at(work["run_at"]).year
 
         assert_equal "{}", work.payload
-        assert_equal({}, work.job)
-        assert_equal({}, work["payload"])
+        assert_equal({}, work.job.item)
         assert_equal(Time.now.year, work.run_at.year)
         assert_equal "default", work.queue
         assert_equal "1234", work.thread_id

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -634,12 +634,19 @@ describe "API" do
         c.hset(s, "1234", data)
       end
 
-      w.each do |p, x, y|
+      w.each do |p, x, work|
         assert_equal key, p
         assert_equal "1234", x
-        assert_equal "default", y["queue"]
-        assert_equal("{}", y["payload"])
-        assert_equal Time.now.year, Time.at(y["run_at"]).year
+        assert_equal "default", work["queue"]
+        assert_equal("{}", work["payload"])
+        assert_equal Time.now.year, Time.at(work["run_at"]).year
+
+        assert_equal "{}", work.payload
+        assert_equal({}, work.job)
+        assert_equal(Time.now.year, work.run_at.year)
+        assert_equal "default", work.queue
+        assert_equal "1234", work.thread_id
+        assert_equal key, work.process_id
       end
 
       s = "#{key}:work"

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -71,7 +71,7 @@ describe Sidekiq::Web do
         conn.sadd("processes", ["foo:1234"])
         conn.hset("foo:1234", "info", Sidekiq.dump_json("hostname" => "foo", "started_at" => Time.now.to_f, "queues" => [], "concurrency" => 10), "at", Time.now.to_f, "busy", 4)
         identity = "foo:1234:work"
-        hash = {queue: "critical", payload: {"class" => WebJob.name, "args" => [1, "abc"]}, run_at: Time.now.to_i}
+        hash = {queue: "critical", payload: Sidekiq.dump_json({"class" => WebJob.name, "args" => [1, "abc"]}), run_at: Time.now.to_i}
         conn.hset(identity, 1001, Sidekiq.dump_json(hash))
       end
       assert_equal ["1001"], Sidekiq::WorkSet.new.map { |pid, tid, data| tid }
@@ -484,7 +484,7 @@ describe Sidekiq::Web do
       conn.sadd("processes", [pro])
       conn.hset(pro, "info", Sidekiq.dump_json("started_at" => Time.now.to_f, "labels" => ["frumduz"], "queues" => [], "concurrency" => 10), "busy", 1, "beat", Time.now.to_f)
       identity = "#{pro}:work"
-      hash = {queue: "critical", payload: {"class" => "FailJob", "args" => ["<a>hello</a>"]}, run_at: Time.now.to_i}
+      hash = {queue: "critical", payload: Sidekiq.dump_json({"class" => "FailJob", "args" => ["<a>hello</a>"]}), run_at: Time.now.to_i}
       conn.hset(identity, 100001, Sidekiq.dump_json(hash))
       conn.incr("busy")
     end

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -125,14 +125,14 @@
       <th><%= t('Arguments') %></th>
       <th><%= t('Started') %></th>
     </thead>
-    <% @workset.each do |process, thread, msg| %>
-      <% job = Sidekiq::JobRecord.new(msg['payload']) %>
+    <% @workset.each do |process, thread, work| %>
+      <% job = work.job %>
       <tr>
         <td><%= process %></td>
         <td><%= thread %></td>
         <td><%= job.jid %></td>
         <td>
-          <a href="<%= root_path %>queues/<%= msg['queue'] %>"><%= msg['queue'] %></a>
+          <a href="<%= root_path %>queues/<%= work.queue %>"><%= work.queue %></a>
         </td>
         <td>
           <%= job.display_class %>
@@ -141,7 +141,7 @@
         <td>
           <div class="args"><%= display_args(job.display_args) %></div>
         </td>
-        <td><%= relative_time(Time.at(msg['run_at'])) %></td>
+        <td><%= relative_time(work.run_at) %></td>
       </tr>
     <% end %>
   </table>


### PR DESCRIPTION
Today, the third parameter in `Sidekiq::WorkSet#each {|process_id, thread_id, work| ... }` is a raw Hash which makes it difficult to change data formats and storage. Introduce a new type `Sidekiq::Work` which represents a job in progress.

Sidekiq 7.0 introduced a slight change in the data format. It was optimized to reduce unnecessary JSON serialization of the "payload" attribute but this changed the data type.

```ruby
Sidekiq::WorkSet.new.each do |pid, tid, work|
  # old, <= 6.x
  work["payload"]["jid"]
  # old, 7.0 -> 7.2.0
  Sidekiq.load_json(work["payload"])["jid"]
  # new, main
  work["payload"]["jid"]
  work.job["jid"]
end
```

This restores compatibility with 6.x but does break compatibility with 7.0 -> 7.2. Any opinions?

See #6145