### PR TITLE
Add a default 5 connections to the capsule pool

### DIFF
--- a/docs/capsule.md
+++ b/docs/capsule.md
@@ -81,6 +81,7 @@ Sidekiq.configure_server do |config|
   config.capsule("unsafe") do |capsule|
     capsule.queues = %w(thread_unsafe)
     capsule.concurrency = 1
+    capsule.extra_connections = 5
   end
 end
 ```
@@ -91,6 +92,11 @@ The contents of `config/sidekiq.yml` configure the default capsule.
 
 Before 7.0, the Sidekiq process would create one redis pool sized to `concurrency + 5`.
 Now Sidekiq will create multiple Redis pools: an internal pool of **ten** connections available to Sidekiq components along with a pool of **concurrency** for the job processors within each Capsule.
+
+In Sidekiq 7.3, the Capsule defaults to a pool size of `concurrency + 5` to [fix intermittent timeout errors](https://github.com/sidekiq/sidekiq/issues/5929).
+The `extra_connections` parameter may be increased if the jobs
+themselves check out a capsule connection via `Sidekiq.redis` and
+encounter delays waiting for a connection to be available.
 
 For a Sidekiq process with a default Capsule and a single threaded Capsule, you should have three Redis pools of size 5, 10 and 1.
 Remember that connection pools are lazy so it won't create all those connections unless they are actively needed.

--- a/lib/sidekiq/capsule.rb
+++ b/lib/sidekiq/capsule.rb
@@ -18,9 +18,12 @@ module Sidekiq
   class Capsule
     include Sidekiq::Component
 
+    DEFAULT_EXTRA_CONNECTIONS = 5
+
     attr_reader :name
     attr_reader :queues
     attr_accessor :concurrency
+    attr_accessor :extra_connections
     attr_reader :mode
     attr_reader :weights
 
@@ -30,6 +33,7 @@ module Sidekiq
       @queues = ["default"]
       @weights = {"default" => 0}
       @concurrency = config[:concurrency]
+      @extra_connections = config[:extra_connections] || DEFAULT_EXTRA_CONNECTIONS
       @mode = :strict
     end
 
@@ -91,7 +95,7 @@ module Sidekiq
     def local_redis_pool
       # connection pool is lazy, it will not create connections unless you actually need them
       # so don't be skimpy!
-      @redis ||= config.new_redis_pool(@concurrency, name)
+      @redis ||= config.new_redis_pool(pool_size, name)
     end
 
     def redis
@@ -122,6 +126,10 @@ module Sidekiq
 
     def logger
       config.logger
+    end
+
+    def pool_size
+      @concurrency.to_i + @extra_connections.to_i
     end
   end
 end

--- a/test/capsule_test.rb
+++ b/test/capsule_test.rb
@@ -19,8 +19,8 @@ describe Sidekiq::Capsule do
     assert_equal one.redis_pool, one.redis_pool
     assert_equal two.redis_pool, two.redis_pool
     # they are sized correctly
-    assert_equal 2, one.redis_pool.size
-    assert_equal 3, two.redis_pool.size
+    assert_equal 2 + Sidekiq::Capsule::DEFAULT_EXTRA_CONNECTIONS, one.redis_pool.size
+    assert_equal 3 + Sidekiq::Capsule::DEFAULT_EXTRA_CONNECTIONS, two.redis_pool.size
     refute_equal one.redis_pool, two.redis_pool
 
     # they point to the same Redis

--- a/test/redis_connection_test.rb
+++ b/test/redis_connection_test.rb
@@ -63,8 +63,8 @@ describe Sidekiq::RedisConnection do
         assert_equal 10, pool.size
       end
 
-      it "sizes capsule pools based on concurrency" do
-        assert_equal 12, @config.default_capsule.redis_pool.size
+      it "sizes capsule pools based on concurrency + 5 spare" do
+        assert_equal 17, @config.default_capsule.redis_pool.size
       end
 
       it "does not change client pool sizes with ENV" do
@@ -74,6 +74,18 @@ describe Sidekiq::RedisConnection do
         assert_equal 10, pool.size
       ensure
         ENV.delete("RAILS_MAX_THREADS")
+      end
+
+      context 'when extra connections are set' do
+        before do
+          @config = reset!
+          @config.default_capsule.concurrency = 12
+          @config.default_capsule.extra_connections = 2
+        end
+
+        it 'sizes capsule pools based on concurrency and extra connections' do
+          assert_equal 14, @config.default_capsule.redis_pool.size
+        end
       end
     end
 


### PR DESCRIPTION
In Sidekiq 6, there was one connection pool of size concurrency +
5. In Sidekiq 7, a capsule has its own connection pool of size concurrency, and there is an internal Sidekiq connection pool with a fixed size of 10.

If you have Sidekiq jobs that run and access `Sidekiq.redis`--which accesses the capsule's connection pool--users can run into an issue where a connection doesn't become available until a BRPOP returns from another job.

This commit adds 5 additional connections to the capsule pool, which is configurable via the `extra_connections` parameter. This should be a reasonable default that ensures Sidekiq 7 jobs avoid pool contention delays.

Relates to https://github.com/sidekiq/sidekiq/issues/5929