### PR TITLE
fix: invoke perform_one, but Queues not delete the job

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -278,7 +278,7 @@ module Sidekiq
       def perform_one
         raise(EmptyQueueError, "perform_one called with empty job queue") if jobs.empty?
         next_job = jobs.first
-        Queues.delete_for(next_job["jid"], queue, to_s)
+        Queues.delete_for(next_job["jid"], next_job["queue"], to_s)
         process_job(next_job)
       end
 


### PR DESCRIPTION
In test environment
1、Sidekiq::Extensions::DelayedClass.perform_one
2、Sidekiq::Queues.jobs_by_worker is empty，but Sidekiq::Queues.jobs_by_queue has the job yet

