### PR TITLE
fix: fix determine_redis_provider test behaviour

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -66,9 +66,7 @@ module Sidekiq
           EOM
         end
 
-        ENV[
-          p || "REDIS_URL"
-        ]
+        ENV[p.to_s] || ENV["REDIS_URL"]
       end
     end
   end


### PR DESCRIPTION
Unit tests fails when a different REDIS_URL is defined since the provider string `p` could be an empty string (effectively returning `ENV['']` or `nil`). This causes all `Sidekiq::RedisConnections` to use the default `redis://127.0.0.1:6379` as the connection parameters.

This PR proposes a fix by doing a boolean `||` on the `ENV` value rather than on the key.

**To replicate:**

When using `localhost:6379`, the specs pass. 
1. Run `docker run -p 6379:6379 -d redis:6.2-alpine`
2. Run `bundle exec rake`

When using a different redis address, the specs fail
1. Run `docker run -p 6380:6379 -d redis:6.2-alpine`. Be sure to stop previous docker container running with exposed port `6379`.
2. Run `REDIS_URL=redis://localhost:6380 bundle exec rake`

```
rails test /Users/sylvesterchin/slaifork/sidekiq/test/retry_test.rb:212

E

Error:
Sidekiq::JobRetry::middleware#test_0013_shuts down without retrying work-in-progress, which will resume:
RedisClient::CannotConnectError: Connection refused - connect(2) for 127.0.0.1:6379

```