### PR TITLE
Fix sidekiq.service for use as user service

### DIFF
--- a/examples/systemd/sidekiq.service
+++ b/examples/systemd/sidekiq.service
@@ -91,3 +91,5 @@ SyslogIdentifier=sidekiq
 
 [Install]
 WantedBy=multi-user.target
+# Uncomment this and remove the line above if you are going to use this as a user service
+# WantedBy=default.target


### PR DESCRIPTION
When rebooting the system, the user service was not launched automatically.