### PR TITLE
fix: Avoid JSON dump on Rails.application

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -20,6 +20,10 @@ module Sidekiq
       def inspect
         "#<Sidekiq::Rails::Reloader @app=#{@app.class.name}>"
       end
+
+      def to_hash
+        { app: @app.class.name }
+      end
     end
 
     # By including the Options module, we allow AJs to directly control sidekiq features


### PR DESCRIPTION
Rails enhances `Object` with `#as_json` that either uses `#to_hash`, or builds Hash of instance variables to their values. During boot process Sidekiq sends debug event with context that includes `:reloader`. As Reloader class has `@app = Rails.application` that causes stak level too deep one-off failure.