### PR TITLE
Change log level from info to debug

### DIFF
--- a/lib/sidekiq/job_logger.rb
+++ b/lib/sidekiq/job_logger.rb
@@ -8,15 +8,15 @@ module Sidekiq
 
     def call(item, queue)
       start = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
-      @logger.info("start")
+      @logger.debug("start")
 
       yield
 
       Sidekiq::Context.add(:elapsed, elapsed(start))
-      @logger.info("done")
+      @logger.debug("done")
     rescue Exception
       Sidekiq::Context.add(:elapsed, elapsed(start))
-      @logger.info("fail")
+      @logger.debug("fail")
 
       raise
     end


### PR DESCRIPTION
## Problem
We noticed we log "start" and "done" hundreds of thousands of times in our job runners.

## Proposed solution

There is very little information in these log lines, and they are very high-frequency logs. Arguably log levels in an application could be set to WARN to avoid these, but the level of granularity here subjectively feels like debugging information.