### PR TITLE
Allow user to disable default job logging

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -36,7 +36,7 @@ module Sidekiq
       @job = nil
       @thread = nil
       @reloader = Sidekiq.default_configuration[:reloader]
-      @job_logger = (capsule.config[:job_logger] || Sidekiq::JobLogger).new(logger)
+      @job_logger = (capsule.config[:job_logger] || Sidekiq::JobLogger).new(capsule.config)
       @retrier = Sidekiq::JobRetry.new(capsule)
     end
 

--- a/test/job_logger_test.rb
+++ b/test/job_logger_test.rb
@@ -21,8 +21,24 @@ describe "Job logger" do
     Thread.current[:sidekiq_tid] = nil
   end
 
+  it "allows output to be disabled" do
+    @logger.formatter = Sidekiq::Logger::Formatters::Pretty.new
+    @cfg[:skip_default_job_logging] = true
+
+    jl = Sidekiq::JobLogger.new(@cfg)
+    @logger.info "mike"
+    job = {"jid" => "1234abc", "wrapped" => "FooJob", "class" => "Wrapper", "tags" => ["bar", "baz"]}
+    jl.prepare(job) do
+      jl.call(job, "queue") {}
+    end
+
+    a, b = @output.string.lines
+    assert_match(/mike/, a)
+    refute b
+  end
+
   it "tests pretty output" do
-    jl = Sidekiq::JobLogger.new(@logger)
+    jl = Sidekiq::JobLogger.new(@cfg)
 
     # pretty
     p = @logger.formatter = Sidekiq::Logger::Formatters::Pretty.new
@@ -45,7 +61,7 @@ describe "Job logger" do
   it "tests json output" do
     # json
     @logger.formatter = Sidekiq::Logger::Formatters::JSON.new
-    jl = Sidekiq::JobLogger.new(@logger)
+    jl = Sidekiq::JobLogger.new(@cfg)
     job = {"jid" => "1234abc", "wrapped" => "Wrapper", "class" => "FooJob", "bid" => "b-xyz", "tags" => ["bar", "baz"]}
     # this mocks what Processor does
     jl.prepare(job) do
@@ -62,7 +78,7 @@ describe "Job logger" do
   end
 
   it "tests custom log level" do
-    jl = Sidekiq::JobLogger.new(@logger)
+    jl = Sidekiq::JobLogger.new(@cfg)
     job = {"class" => "FooJob", "log_level" => "debug"}
 
     assert @logger.info?
@@ -84,7 +100,7 @@ describe "Job logger" do
     @logger = Logger.new(@output, level: :info)
     @cfg.logger = @logger
 
-    jl = Sidekiq::JobLogger.new(@logger)
+    jl = Sidekiq::JobLogger.new(@cfg)
     job = {"class" => "FooJob", "log_level" => "debug"}
 
     assert @logger.info?


### PR DESCRIPTION
This PR adds a new configuration knob, :skip_default_job_logging, to disable job logging out of the box, see #6199.

The user can choose when and where to disable the logging. I would recommend leaving it enabled for a reasonable developer experience but in environments like a high-volume production setup, logging output can be significant. This allows the user to opt-out of the logging if it becomes an issue.

```ruby
Sidekiq.configure_server do |config|
  # disable job logging in production
  config[:skip_default_job_logging] = (config[:environment] == "production")

  # disable sidekiq's job logging everywhere
  config[:skip_default_job_logging] = true
end
```