### PR TITLE
Add ability to find a currently running work by jid

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,11 @@
 
 [Sidekiq Changes](https://github.com/sidekiq/sidekiq/blob/main/Changes.md) | [Sidekiq Pro Changes](https://github.com/sidekiq/sidekiq/blob/main/Pro-Changes.md) | [Sidekiq Enterprise Changes](https://github.com/sidekiq/sidekiq/blob/main/Ent-Changes.md)
 
+HEAD
+----------
+
+- Add ability to find a currently running work by jid [#6212, fatkodima]
+
 7.2.2
 ----------
 

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -1136,6 +1136,20 @@ module Sidekiq
         end
       end
     end
+
+    ##
+    # Find the work which represents a job with the given JID.
+    # *This is a slow O(n) operation*.  Do not use for app logic.
+    #
+    # @param jid [String] the job identifier
+    # @return [Sidekiq::Work] the work or nil
+    def find_work_by_jid(jid)
+      each do |_process_id, _thread_id, work|
+        job = work.job
+        return work if job.jid == jid
+      end
+      nil
+    end
   end
 
   # Sidekiq::Work represents a job which is currently executing.


### PR DESCRIPTION
Closes #6211.

Example:
```ruby
work = WorkSet.find_work_by_jid("abcde")
```