### PR TITLE
Add language selector and session language persistance

### DIFF
--- a/lib/sidekiq/web/action.rb
+++ b/lib/sidekiq/web/action.rb
@@ -22,6 +22,11 @@ module Sidekiq
       throw :halt, [302, {Web::LOCATION => "#{request.base_url}#{location}"}, []]
     end
 
+    def reload_page
+      current_location = request.referer.gsub(request.base_url, "")
+      redirect current_location
+    end
+
     def params
       indifferent_hash = Hash.new { |hash, key| hash[key.to_s] if Symbol === key }
 

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -394,6 +394,18 @@ module Sidekiq
       erb :morgue
     end
 
+    post "/change_locale" do
+      locale = params["locale"]
+
+      match = available_locales.find { |available|
+        locale == available
+      }
+
+      session[:locale] = match if match
+
+      reload_page
+    end
+
     def call(env)
       action = self.class.match(env)
       return [404, {Rack::CONTENT_TYPE => "text/plain", Web::X_CASCADE => "pass"}, ["Not Found"]] unless action

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -121,6 +121,10 @@ module Sidekiq
     #
     # Inspiration taken from https://github.com/iain/http_accept_language/blob/master/lib/http_accept_language/parser.rb
     def locale
+      # session[:locale] is set via the locale selector from the footer
+      # defined?(session) && session are used to avoid exceptions when running tests
+      return session[:locale] if defined?(session) && session&.[](:locale)
+
       @locale ||= begin
         matched_locale = user_preferred_languages.map { |preferred|
           preferred_language = preferred.split("-", 2).first

--- a/test/web_helpers_test.rb
+++ b/test/web_helpers_test.rb
@@ -96,6 +96,18 @@ describe "Web helpers" do
     assert_equal "en", obj.locale
   end
 
+  it "tests user selected locale" do
+    obj = Helpers.new("HTTP_ACCEPT_LANGUAGE" => "*")
+
+    obj.instance_eval do
+      def session
+        {locale: "es"}
+      end
+    end
+
+    assert_equal "es", obj.locale
+  end
+
   it "tests available locales" do
     obj = Helpers.new
     expected = %w[

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -18,12 +18,6 @@ class LogDisplayer
   end
 end
 
-class MockWebAction < Sidekiq::WebAction
-  def self.call(env)
-    [200, {}, []]
-  end
-end
-
 describe Sidekiq::Web do
   include Rack::Test::Methods
 

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -18,6 +18,12 @@ class LogDisplayer
   end
 end
 
+class MockWebAction < Sidekiq::WebAction
+  def self.call(env)
+    [200, {}, []]
+  end
+end
+
 describe Sidekiq::Web do
   include Rack::Test::Methods
 
@@ -598,6 +604,18 @@ describe Sidekiq::Web do
   it "can display home" do
     get "/"
     assert_equal 200, last_response.status
+  end
+
+  it "can change the locale" do
+    session_data = {"rack.session" => {}}
+    headers = {"HTTP_REFERER" => "http://example.org/path", "HTTP_BASE_URL" => "http://example.org/"}
+
+    post "/change_locale", {"locale" => "es"}, session_data.merge(headers)
+
+    assert_equal "es", last_request.env["rack.session"][:locale]
+
+    assert_equal 302, last_response.status
+    assert_equal "http://example.org/path", last_response.location
   end
 
   describe "custom locales" do

--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -47,6 +47,8 @@ function addListeners() {
       scheduleLivePoll();
     }
   }
+
+  document.getElementById("locale-select").addEventListener("change", updateLocale);
 }
 
 function addPollingListeners(_event)  {
@@ -175,3 +177,7 @@ function replacePage(text) {
 function showError(error) {
   console.error(error)
 }
+
+function updateLocale(event) {
+  event.target.form.submit();
+};

--- a/web/assets/stylesheets/application-rtl.css
+++ b/web/assets/stylesheets/application-rtl.css
@@ -155,11 +155,3 @@ div.interval-slider {
 .locale-select {
   float: right;
 }
-
-@media (max-width: 767px) {
-  .locale-select {
-    float: none;
-    line-height: 30px;
-    margin: 11px auto;
-  }
-}

--- a/web/assets/stylesheets/application-rtl.css
+++ b/web/assets/stylesheets/application-rtl.css
@@ -152,6 +152,12 @@ div.interval-slider {
   }
 }
 
-.locale-select {
+#locale-select {
   float: right;
+}
+
+@media (max-width: 767px) {
+  #locale-select {
+    float: none;
+  }
 }

--- a/web/assets/stylesheets/application-rtl.css
+++ b/web/assets/stylesheets/application-rtl.css
@@ -154,16 +154,6 @@ div.interval-slider {
 
 .locale-select {
   float: right;
-  color: #ddd;
-  width: 66px;
-  margin: 11px 15px;
-  padding: 4px;
-  border-radius: 4px;
-  background-color: transparent;
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-  transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
-  -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
 }
 
 @media (max-width: 767px) {

--- a/web/assets/stylesheets/application-rtl.css
+++ b/web/assets/stylesheets/application-rtl.css
@@ -151,3 +151,25 @@ div.interval-slider {
     padding-left: 5px;
   }
 }
+
+.locale-select {
+  float: right;
+  color: #ddd;
+  width: 66px;
+  margin: 11px 15px;
+  padding: 4px;
+  border-radius: 4px;
+  background-color: transparent;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+  transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
+  -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
+}
+
+@media (max-width: 767px) {
+  .locale-select {
+    float: none;
+    line-height: 30px;
+    margin: 11px auto;
+  }
+}

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -732,31 +732,15 @@ canvas {
   margin: 20px 0 30px;
 }
 
-.locale-select {
+#locale-select {
   float: left;
-  color: #ddd;
-  width: 66px;
-  margin: 11px 15px;
-  padding: 4px;
-  border-radius: 4px;
-  background-color: transparent;
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-  transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
-  -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
-}
-
-.locale-select:focus {
-  border-color: #66afe9;
-  outline: 0;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102,175,233,.6);
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102,175,233,.6);
+  margin: 8px 15px;
 }
 
 @media (max-width: 767px) {
-  .locale-select {
+  #locale-select {
     float: none;
-    line-height: 30px;
-    margin: 11px auto;
+    width: auto;
+    margin: 15px auto;
   }
 }

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -731,3 +731,32 @@ div.interval-slider input {
 canvas {
   margin: 20px 0 30px;
 }
+
+.locale-select {
+  float: left;
+  color: #ddd;
+  width: 66px;
+  margin: 11px 15px;
+  padding: 4px;
+  border-radius: 4px;
+  background-color: transparent;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+  transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
+  -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
+}
+
+.locale-select:focus {
+  border-color: #66afe9;
+  outline: 0;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102,175,233,.6);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102,175,233,.6);
+}
+
+@media (max-width: 767px) {
+  .locale-select {
+    float: none;
+    line-height: 30px;
+    margin: 11px auto;
+  }
+}

--- a/web/views/_footer.erb
+++ b/web/views/_footer.erb
@@ -15,7 +15,18 @@
             <p class="navbar-text"><a rel=help href="https://github.com/sidekiq/sidekiq/wiki">docs</a></p>
           </li>
           <li>
-            <p class="navbar-text"><a rel=external href="https://github.com/sidekiq/sidekiq/tree/main/web/locales"><%= locale %></a></p>
+            <form id="locale-form" action="<%= root_path %>change_locale" method="post">
+              <%= csrf_tag %>
+              <select id="locale-select" class="locale-select" name="locale">
+                <% available_locales.each do |locale_option| %>
+                  <% if locale_option === locale %>
+                    <option selected value="<%= locale_option %>"><%= locale_option %></option>
+                  <% else %>
+                    <option value="<%= locale_option %>"><%= locale_option %></option>
+                  <% end %>
+                <% end %>
+              </select>
+            </form>
           </li>
         </ul>
     </div>

--- a/web/views/_footer.erb
+++ b/web/views/_footer.erb
@@ -15,9 +15,10 @@
             <p class="navbar-text"><a rel=help href="https://github.com/sidekiq/sidekiq/wiki">docs</a></p>
           </li>
           <li>
-            <form id="locale-form" action="<%= root_path %>change_locale" method="post">
+            <form id="locale-form" class="form-inline" action="<%= root_path %>change_locale" method="post">
               <%= csrf_tag %>
-              <select id="locale-select" class="locale-select" name="locale">
+              <label class="sr-only" for="locale">Language</label>
+              <select id="locale-select" class="form-control" name="locale">
                 <% available_locales.each do |locale_option| %>
                   <% if locale_option == locale %>
                     <option selected value="<%= locale_option %>"><%= locale_option %></option>

--- a/web/views/_footer.erb
+++ b/web/views/_footer.erb
@@ -19,7 +19,7 @@
               <%= csrf_tag %>
               <select id="locale-select" class="locale-select" name="locale">
                 <% available_locales.each do |locale_option| %>
-                  <% if locale_option === locale %>
+                  <% if locale_option == locale %>
                     <option selected value="<%= locale_option %>"><%= locale_option %></option>
                   <% else %>
                     <option value="<%= locale_option %>"><%= locale_option %></option>


### PR DESCRIPTION
This pull request introduces a language selector to the footer of the web UI. Additionally, it ensures that the selected locale persists throughout the current session. If the user doesn't choose a language, it will default to their preferred one.

### Screenshots

**Desktop**
![Screenshot 2024-03-08 at 19 56 02](https://github.com/sidekiq/sidekiq/assets/37131677/fe22b0f6-631b-4f73-a5e0-390c71da75f0)
![Screenshot 2024-03-08 at 19 56 18](https://github.com/sidekiq/sidekiq/assets/37131677/79f5e68f-401d-45ca-b32b-c58bfcf70540)
![Screenshot 2024-03-08 at 19 56 33](https://github.com/sidekiq/sidekiq/assets/37131677/b848c28b-7577-48bf-85bb-97fcf8ad5766)

**Mobile**
![Screenshot 2024-03-08 at 19 57 46](https://github.com/sidekiq/sidekiq/assets/37131677/9a8310d3-b1e5-4259-bb09-d9b04775e2b5)
![Screenshot 2024-03-08 at 19 57 58](https://github.com/sidekiq/sidekiq/assets/37131677/f9132928-0bde-4a1d-80d6-5cf4fa68288d)
