### PR TITLE
Fix: Latency eq 0 is not a float

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -269,7 +269,7 @@ module Sidekiq
       job = Sidekiq.load_json(entry)
       now = Time.now.to_f
       thence = job["enqueued_at"] || now
-      now - thence
+      (now - thence).to_f
     end
 
     def each


### PR DESCRIPTION
## What?

According to docs `latency` is 0 but looks like this is not true.
Zero is an exception there. 
Could we fix this? Tiny change but makes difference. :)

## Why?
```
[4] pry(main)> Sidekiq::Queue.all.last.latency.is_a?(Float)
=> false
```

`0-0` -> 0


Link:
https://www.rubydoc.info/github/mperham/sidekiq/Sidekiq/Queue#latency-instance_method
