### PR TITLE
Add `disable_retry_jitter` parameter to `sidekiq_options`

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -184,7 +184,8 @@ module Sidekiq
 
       # Logging here can break retries if the logging device raises ENOSPC #3979
       # logger.debug { "Failure! Retry #{count} in #{delay} seconds" }
-      jitter = rand(10) * (count + 1)
+      disable_rety_jitter = msg["disable_retry_jitter"].is_a?(TrueClass)
+      jitter = !disable_rety_jitter ? rand(10) * (count + 1) : 0
       retry_at = Time.now.to_f + delay + jitter
       payload = Sidekiq.dump_json(msg)
       redis do |conn|


### PR DESCRIPTION
## Purpose of the Change

This pull request introduces a new parameter `disable_retry_jitter` to `sidekiq_options`, allowing users to disable the addition of random jitter to the retry delay.

## Details of the Change

- Introduced a new boolean parameter `disable_retry_jitter` in `sidekiq_options`
- The `process_retry` method now checks this parameter to determine whether to apply jitter to the `retry_at` calculation
- If `disable_retry_jitter` is true, no jitter is added; otherwise, the behavior remains as it was.

## Rationale

The addition of this parameter offers greater control over the retry mechanism, particularly in environments where predictable retry timing is essential (even if the retry mechanism is deliberately not designed to be precise). By allowing the disabling of retry jitter, users can ensure more deterministic retry intervals, which can be crucial for certain use cases or testing environments.

## Impact

This change is backward compatible and should not affect existing users who do not opt to use this new parameter. It introduces an additional feature that enhances configurability without altering the default behavior of Sidekiq.