### PR TITLE
Add `disable_max_retries` option to `sidekiq_options` to Conditionally Disable Max Retries

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -169,7 +169,9 @@ module Sidekiq
         msg["error_backtrace"] = compress_backtrace(lines)
       end
 
-      return retries_exhausted(jobinst, msg, exception) if count >= max_retry_attempts
+      disable_max_retries = msg["retry_for"] && msg["disable_max_retries"].is_a?(TrueClass)
+
+      return retries_exhausted(jobinst, msg, exception) if !disable_max_retries && count >= max_retry_attempts
 
       rf = msg["retry_for"]
       return retries_exhausted(jobinst, msg, exception) if rf && ((msg["failed_at"] + rf) < Time.now.to_f)


### PR DESCRIPTION
## Purpose of the Change

This pull request adds a new `disable_max_retries` parameter to `sidekiq_options`, enabling users to disable the max retries limit under specific conditions. This feature requires both `disable_max_retries` and `retry_for` to be set, which ensures that it is used deliberately and reduces the risk of creating infinite job loops.

## Details of the Change

- A new boolean parameter `disable_max_retries` has been introduced, which works in conjunction with `retry_for`
- The job retry logic now checks both `retry_for` and `disable_max_retries` before deciding whether to exhaust retries
- This change allows jobs to bypass the max retry attempts limit if and only if `disable_max_retries` is true and `retry_for` is specified

## Rationale

This update gives users more flexibility in handling retries, particularly for jobs that might require special retry logic under certain conditions. By necessitating the concurrent setting of `retry_for`, it ensures that this feature is used judiciously, mitigating potential risks associated with disabling max retries. I think the current behavior of `retry_for` could be easily misunderstood due to the close, and in my opinion not very explicit, relationship that exists with the `retry` option.

## Impact

This enhancement is backward compatible and introduces a conditional feature that adds granularity to job retry management without affecting the existing functionality. It is especially useful in scenarios where advanced retry logic is necessary, providing users with the option to fine-tune job retries according to their specific requirements.
