### PR TITLE
Fix typos

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -9,7 +9,7 @@ Sidekiq provides a number of public APIs for various functionality.
 
 ## Middleware
 
-Middleware run around the the client-side push and the server-side execution of jobs. This allows plugins which mutate job data or provide additional functionality during the executiong of specific jobs.
+Middleware run around the the client-side push and the server-side execution of jobs. This allows plugins which mutate job data or provide additional functionality during the executing of specific jobs.
 
 ## Lifecycle Events
 

--- a/lib/sidekiq/deploy.rb
+++ b/lib/sidekiq/deploy.rb
@@ -34,7 +34,7 @@ module Sidekiq
       # handle an very common error in marking deploys:
       # having every process mark its deploy, leading
       # to N marks for each deploy. Instead we round the time
-      # to the minute so that multple marks within that minute
+      # to the minute so that multiple marks within that minute
       # will all naturally rollup into one mark per minute.
       whence = at.utc
       floor = Time.utc(whence.year, whence.month, whence.mday, whence.hour, whence.min, 0)

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -187,7 +187,7 @@ module Sidekiq
           # we didn't properly finish it.
         rescue Sidekiq::JobRetry::Handled => h
           # this is the common case: job raised error and Sidekiq::JobRetry::Handled
-          # signals that we created a retry successfully.  We can acknowlege the job.
+          # signals that we created a retry successfully.  We can acknowledge the job.
           ack = true
           e = h.cause || h
           handle_exception(e, {context: "Job raised exception", job: job_hash})

--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -144,7 +144,7 @@ module Sidekiq
         # In the example above, each process should schedule every 10 seconds on average. We special
         # case smaller clusters to add 50% so they would sleep somewhere between 5 and 15 seconds.
         # As we run more processes, the scheduling interval average will approach an even spread
-        # between 0 and poll interval so we don't need this artifical boost.
+        # between 0 and poll interval so we don't need this artificial boost.
         #
         count = process_count
         interval = poll_interval_average(count)

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -112,7 +112,7 @@ module Sidekiq
     # The Queues class is only for testing the fake queue implementation.
     # There are 2 data structures involved in tandem. This is due to the
     # Rspec syntax of change(HardJob.jobs, :size). It keeps a reference
-    # to the array. Because the array was dervied from a filter of the total
+    # to the array. Because the array was derived from a filter of the total
     # jobs enqueued, it appeared as though the array didn't change.
     #
     # To solve this, we'll keep 2 hashes containing the jobs. One with keys based

--- a/lib/sidekiq/web/csrf_protection.rb
+++ b/lib/sidekiq/web/csrf_protection.rb
@@ -115,7 +115,7 @@ module Sidekiq
         sess = session(env)
         localtoken = sess[:csrf]
 
-        # Checks that Rack::Session::Cookie actualy contains the csrf toekn
+        # Checks that Rack::Session::Cookie actually contains the csrf token
         return false if localtoken.nil?
 
         # Rotate the session token after every use

--- a/test/actors_test.rb
+++ b/test/actors_test.rb
@@ -73,7 +73,7 @@ describe "Actors" do
     it "can stop" do
       f = Sidekiq::Processor.new(@cap) { |p, ex| raise "should not raise!" }
       f.terminate
-      assert_nil f.thread # didnt start it
+      assert_nil f.thread # didn't start it
     end
 
     it "deals with errors" do

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -266,7 +266,7 @@ describe "API" do
 
     it "enumerates jobs in descending score order" do
       # We need to enqueue more than 50 items, which is the page size when retrieving
-      # from Redis to ensure everything is sorted: the pages and the items withing them.
+      # from Redis to ensure everything is sorted: the pages and the items within them.
       51.times { ApiJob.perform_in(100, 1, "foo") }
 
       set = Sidekiq::ScheduledSet.new.to_a

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -225,7 +225,7 @@ describe Sidekiq::CLI do
 
       describe "default config file" do
         describe "when required path is a directory" do
-          it "tries config/sidekiq.yml from required diretory" do
+          it "tries config/sidekiq.yml from required directory" do
             @cli.parse(%w[sidekiq -r ./test/dummy])
 
             assert_equal "./test/dummy/config/sidekiq.yml", config[:config_file]
@@ -234,7 +234,7 @@ describe Sidekiq::CLI do
         end
 
         describe "when required path is a file" do
-          it "tries config/sidekiq.yml from current diretory" do
+          it "tries config/sidekiq.yml from current directory" do
             config[:require] = "./test/dummy" # stub current dir – ./
 
             @cli.parse(%w[sidekiq -r ./test/fake_env.rb])
@@ -245,7 +245,7 @@ describe Sidekiq::CLI do
         end
 
         describe "without any required path" do
-          it "tries config/sidekiq.yml from current diretory" do
+          it "tries config/sidekiq.yml from current directory" do
             config[:require] = "./test/dummy" # stub current dir – ./
 
             @cli.parse(%w[sidekiq])

--- a/test/csrf_test.rb
+++ b/test/csrf_test.rb
@@ -50,7 +50,7 @@ describe "Csrf" do
 
   it "bad post" do
     result = call(env(:post)) do
-      raise "Shouldnt be called"
+      raise "Shouldn't be called"
     end
     refute_nil result
     assert_equal 403, result[0]
@@ -79,7 +79,7 @@ describe "Csrf" do
   it "fails with bad token" do
     # Make a POST with a known bad token
     result = call(env(:post, "authenticity_token" => "N0QRBD34tU61d7fi+0ZaF/35JLW/9K+8kk8dc1TZoK/0pTl7GIHap5gy7BWGsoKlzbMLRp1yaDpCDFwTJtxWAg==")) do
-      raise "shouldnt be called"
+      raise "shouldn't be called"
     end
     refute_nil result
     assert_equal 403, result[0]
@@ -95,7 +95,7 @@ describe "Csrf" do
 
     # Make a POST with an empty session data and good token
     result = call(env(:post, {"authenticity_token" => goodtoken}, {})) do
-      raise "shouldnt be called"
+      raise "shouldn't be called"
     end
     refute_nil result
     assert_equal 403, result[0]
@@ -111,7 +111,7 @@ describe "Csrf" do
 
     # Make a POST without csrf session data and good token
     result = call(env(:post, {"authenticity_token" => goodtoken}, {"session_id" => "foo"})) do
-      raise "shouldnt be called"
+      raise "shouldn't be called"
     end
     refute_nil result
     assert_equal 403, result[0]

--- a/test/current_attributes_test.rb
+++ b/test/current_attributes_test.rb
@@ -57,7 +57,7 @@ describe "Current attributes" do
       assert_equal 123, Myapp::Current.user_id
       assert_equal 456, Myapp::OtherCurrent.other_id
     end
-    # the Rails reloader is responsible for reseting Current after every unit of work
+    # the Rails reloader is responsible for resetting Current after every unit of work
   end
 
   it "persists with class argument" do

--- a/test/retry_exhausted_test.rb
+++ b/test/retry_exhausted_test.rb
@@ -203,7 +203,7 @@ describe "sidekiq_retries_exhausted" do
     assert exhausted_exception
   end
 
-  it "supports discard option to disble global failure handlers and dead set" do
+  it "supports discard option to disable global failure handlers and dead set" do
     discard_job = DiscardJob.new
 
     exhausted_job = nil

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -423,7 +423,7 @@ describe Sidekiq::JobRetry do
       end
     end
 
-    describe "handles errors withouth cause" do
+    describe "handles errors without cause" do
       before do
         @error = nil
         begin

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -912,7 +912,7 @@ describe Sidekiq::Web do
       refute_nil last_response.header["WWW-Authenticate"]
     end
 
-    it "authenticates successfuly" do
+    it "authenticates successfully" do
       basic_authorize "a", "b"
 
       get "/"


### PR DESCRIPTION
Found via `codespell -S ./web/locales,./web/assets -L strat,befores`