### PR TITLE
Add **kwargs to dynamic redis client method definition

### DIFF
--- a/lib/sidekiq/redis_client_adapter.rb
+++ b/lib/sidekiq/redis_client_adapter.rb
@@ -32,8 +32,8 @@ module Sidekiq
         zremrangebyrank zremrangebyscore]
 
       USED_COMMANDS.each do |name|
-        define_method(name) do |*args|
-          @client.call(name, *args)
+        define_method(name) do |*args, **kwargs|
+          @client.call(name, *args, **kwargs)
         end
       end
 

--- a/lib/sidekiq/version.rb
+++ b/lib/sidekiq/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Sidekiq
-  VERSION = "7.2.2"
+  VERSION = "7.2.3"
   MAJOR = 7
 end


### PR DESCRIPTION
This will allow to avoid Ruby deprecation warnings on Ruby 2.7
```
gems/sidekiq-7.2.2/lib/sidekiq/redis_client_adapter.rb:36: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
gems/redis-client-0.21.1/lib/redis_client.rb:275: warning: The called method `call' is defined here
```
Testing env: 
```ruby
Warning[:deprecated] = true
def call(*command, **kwargs)
  puts command, kwargs
end

def wcall(*args); call(*args);end

def wcall2(*args, **kwargs); call(*args, **kwargs);end
```

Testing: 
```
irb(main):019:0> wcall(1,2,3, foo: 'bar')
(irb):15: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
(irb):12: warning: The called method `call' is defined here
1
2
3
{:foo=>"bar"}
=> nil
irb(main):020:0> wcall2(1,2,3, foo: 'bar')
1
2
3
{:foo=>"bar"}
=> nil
```