### PR TITLE
Convert Redis options nested keys to symbols

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -8,7 +8,7 @@ module Sidekiq
   module RedisConnection
     class << self
       def create(options = {})
-        symbolized_options = options.transform_keys(&:to_sym)
+        symbolized_options = deep_symbolize_keys(options)
         symbolized_options[:url] ||= determine_redis_provider
 
         logger = symbolized_options.delete(:logger)
@@ -26,6 +26,19 @@ module Sidekiq
       end
 
       private
+
+      def deep_symbolize_keys(object)
+        case object
+        when Hash
+          object.each_with_object({}) do |(key, value), result|
+            result[key.to_sym] = deep_symbolize_keys(value)
+          end
+        when Array
+          object.map { |e| deep_symbolize_keys(e) }
+        else
+          object
+        end
+      end
 
       def scrub(options)
         redacted = "REDACTED"

--- a/test/redis_connection_test.rb
+++ b/test/redis_connection_test.rb
@@ -187,6 +187,26 @@ describe Sidekiq::RedisConnection do
         refute_includes(output, "ssl_params")
       end
     end
+
+    it "symbolizes redis options keys" do
+      options = {
+        "name" => "mymaster",
+        "sentinels" => [
+          {"host" => "host1", "port" => 26379, "password" => "secret"},
+          {"host" => "host2", "port" => 26379, "password" => "secret"},
+          {"host" => "host3", "port" => 26379, "password" => "secret"}
+        ]
+      }
+
+      pool = Sidekiq::RedisConnection.create(options)
+      config = config_for(pool.checkout)
+
+      config.sentinels.each.with_index do |sentinel_config, idx|
+        assert_equal options["sentinels"][idx]["host"], sentinel_config.host
+        assert_equal options["sentinels"][idx]["port"], sentinel_config.port
+        assert_equal options["sentinels"][idx]["password"], sentinel_config.password
+      end
+    end
   end
 
   describe ".determine_redis_provider" do


### PR DESCRIPTION
[The docs says](https://github.com/sidekiq/sidekiq/wiki/Using-Redis#using-an-initializer)

> Keys can be strings or symbols and will be unified before being passed on to the Redis client.

But it doesn't work with nested keys in the options.

```ruby
Sidekiq.configure_server do |config|
  config.redis = {
    "name" => "mymaster",
    "sentinels" => [
      { "host" => "redis-node-1", "port" => 26379 },
      { "host" => "redis-node-2", "port" => 26379 },
      { "host" => "redis-node-3", "port" => 26379 }
    ]
  }
end
```

We're parsing the configuration from a YAML file and the hash comes out naturally with string keys. It would be nice to handle the conversion automatically.
