### PR TITLE
Make Sidekiq Web UI test less flaky

### DIFF
--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -127,9 +127,12 @@ describe Sidekiq::Web do
   end
 
   it "can display queues" do
-    assert Sidekiq::Client.push("queue" => :foo, "class" => WebJob, "args" => [1, 3])
+    Time.stub(:now, Time.now) do
+      assert Sidekiq::Client.push("queue" => :foo, "class" => WebJob, "args" => [1, 3])
 
-    get "/queues"
+      get "/queues"
+    end
+
     assert_equal 200, last_response.status
     assert_match(/foo/, last_response.body)
     refute_match(/HardJob/, last_response.body)


### PR DESCRIPTION
The Sidekiq Web UI test attempts to test that the latency shown in the queues page is 0.0. However, if there is some slowness in the test the latency could tick up to a second, causing the test to fail.

Avoid this flakiness by stubbing `Time.now` so that we guarantee that the latency will always remain at 0.