### PR TITLE
Relax CSP for `style-src`

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -16,7 +16,7 @@ module Sidekiq
       "media-src 'self'",
       "object-src 'none'",
       "script-src 'self' 'nonce-!placeholder!'",
-      "style-src 'self' 'nonce-!placeholder!'",
+      "style-src 'self' https: http: 'unsafe-inline'", # TODO Nonce in 8.0
       "worker-src 'self'",
       "base-uri 'self'"
     ].join("; ").freeze

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -68,7 +68,7 @@ describe Sidekiq::Web do
     get "/", {}
     policies = last_response.headers["Content-Security-Policy"].split("; ")
     assert_includes(policies, "connect-src 'self' https: http: wss: ws:")
-    assert_includes(policies, "style-src 'self' 'nonce-#{last_request.env[:csp_nonce]}'")
+    assert_includes(policies, "style-src 'self' https: http: 'unsafe-inline'")
     assert_includes(policies, "script-src 'self' 'nonce-#{last_request.env[:csp_nonce]}'")
     assert_includes(policies, "object-src 'none'")
     assert_operator(24, :>=, last_request.env[:csp_nonce].length)


### PR DESCRIPTION
Followup to https://github.com/sidekiq/sidekiq/pull/6270#discussion_r1594433193

A nonce doesn't work with `unsafe-inline`, so just go back to how it was previously. Keep this as a task for later instead.