### PR TITLE
Add iteration support for long-running jobs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,11 @@
 
 [Sidekiq Changes](https://github.com/sidekiq/sidekiq/blob/main/Changes.md) | [Sidekiq Pro Changes](https://github.com/sidekiq/sidekiq/blob/main/Pro-Changes.md) | [Sidekiq Enterprise Changes](https://github.com/sidekiq/sidekiq/blob/main/Ent-Changes.md)
 
+HEAD
+----------
+
+- Add iteration support for long-running jobs [#6286, fatkodima]
+
 7.2.4
 ----------
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "sqlite3", "~> 1.4", platforms: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 gem "after_commit_everywhere", require: false
 gem "yard"
+gem "csv"
 
 group :test do
   gem "maxitest"

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -50,11 +50,6 @@ module Sidekiq
     defined?(Sidekiq::CLI)
   end
 
-  class << self
-    attr_accessor :stopping
-    alias_method :stopping?, :stopping
-  end
-
   def self.load_json(string)
     JSON.parse(string)
   end
@@ -148,12 +143,6 @@ module Sidekiq
   # otherwise Ruby's Thread#kill will commit.  See #377.
   # DO NOT RESCUE THIS ERROR IN YOUR JOBS
   class Shutdown < Interrupt; end
-end
-
-Sidekiq.configure_server do |config|
-  config.on(:quiet) do
-    Sidekiq.stopping = true
-  end
 end
 
 require "sidekiq/rails" if defined?(::Rails::Engine)

--- a/lib/sidekiq/config.rb
+++ b/lib/sidekiq/config.rb
@@ -17,6 +17,10 @@ module Sidekiq
       poll_interval_average: nil,
       average_scheduled_poll_interval: 5,
       on_complex_arguments: :raise,
+      iteration: {
+        max_job_runtime: nil,
+        retry_backoff: 0
+      },
       error_handlers: [],
       death_handlers: [],
       lifecycle_events: {
@@ -52,7 +56,7 @@ module Sidekiq
       @capsules = {}
     end
 
-    def_delegators :@options, :[], :[]=, :fetch, :key?, :has_key?, :merge!
+    def_delegators :@options, :[], :[]=, :fetch, :key?, :has_key?, :merge!, :dig
     attr_reader :capsules
 
     def to_json(*)

--- a/lib/sidekiq/job.rb
+++ b/lib/sidekiq/job.rb
@@ -69,7 +69,11 @@ module Sidekiq
         # In practice, any option is allowed.  This is the main mechanism to configure the
         # options for a specific job.
         def sidekiq_options(opts = {})
-          opts = opts.transform_keys(&:to_s) # stringify
+          # stringify 2 levels of keys
+          opts = opts.to_h do |k, v|
+            [k.to_s, (Hash === v) ? v.transform_keys(&:to_s) : v]
+          end
+
           self.sidekiq_options_hash = get_sidekiq_options.merge(opts)
         end
 

--- a/lib/sidekiq/job/iterable.rb
+++ b/lib/sidekiq/job/iterable.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+require_relative "iterable/enumerators"
+
+module Sidekiq
+  module Job
+    module Iterable
+      class Interrupted < ::RuntimeError; end
+
+      include Enumerators
+
+      # @api private
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
+      # @api private
+      module ClassMethods
+        def method_added(method_name)
+          if method_name == :perform
+            raise "Job that is using Iterable (#{self}) cannot redefine #perform"
+          end
+
+          super
+        end
+      end
+
+      # @api private
+      def initialize
+        super
+
+        @executions = 0
+        @cursor = nil
+        @times_interrupted = 0
+        @start_time = nil
+        @total_time = 0
+      end
+
+      # A hook to override that will be called when the job starts iterating.
+      #
+      # It is called only once, for the first time.
+      #
+      def on_start
+      end
+
+      # A hook to override that will be called around each iteration.
+      #
+      # Can be useful for some metrics collection, performance tracking etc.
+      #
+      def around_iteration
+        yield
+      end
+
+      # A hook to override that will be called when the job resumes iterating.
+      #
+      def on_resume
+      end
+
+      # A hook to override that will be called each time the job is interrupted.
+      #
+      # This can be due to throttling, `max_job_runtime` configuration,
+      # or sidekiq stopping.
+      #
+      def on_shutdown
+      end
+
+      # A hook to override that will be called when the job finished iterating.
+      #
+      def on_complete
+      end
+
+      # The enumerator to be iterated over.
+      #
+      # @return [Enumerator]
+      #
+      # @raise [NotImplementedError] with a message advising subclasses to
+      #     implement an override for this method.
+      #
+      def build_enumerator(*)
+        raise NotImplementedError, "#{self.class.name} must implement a '#build_enumerator' method"
+      end
+
+      # The action to be performed on each item from the enumerator.
+      #
+      # @return [void]
+      #
+      # @raise [NotImplementedError] with a message advising subclasses to
+      #     implement an override for this method.
+      #
+      def each_iteration(*)
+        raise NotImplementedError, "#{self.class.name} must implement an '#each_iteration' method"
+      end
+
+      # A hook to override that can be used to throttle a job when a given condition is met.
+      #
+      # If a job is throttled, it will be interrupted and retried after a backoff period
+      # (0 by default) has passed.
+      #
+      # The backoff can be configured via `sidekiq_options` per job:
+      #
+      #   sidekiq_options iteration: { retry_backoff: 30 } # in seconds
+      #
+      #  or globally:
+      #
+      #   Sidekiq::Config::DEFAULTS[:iteration][:retry_backoff] = 30 # in seconds
+      #
+      # @return [Boolean]
+      #
+      def throttle?
+        false
+      end
+
+      # @api private
+      def perform(*arguments)
+        fetch_previous_iteration_state
+
+        @executions += 1
+        @start_time = Time.now
+
+        enumerator = build_enumerator(*arguments, cursor: @cursor)
+        unless enumerator
+          logger.debug("'#build_enumerator' returned nil, skipping the job.")
+          return
+        end
+
+        assert_enumerator!(enumerator)
+
+        if @executions == 1
+          on_start
+        else
+          on_resume
+        end
+
+        completed = catch(:abort) do
+          iterate_with_enumerator(enumerator, arguments)
+        end
+
+        on_shutdown
+        completed = handle_completed(completed)
+
+        if completed
+          on_complete
+
+          logger.info {
+            format("Completed iterating. times_interrupted=%d total_time=%.3f", @times_interrupted, @total_time)
+          }
+        else
+          reenqueue_iteration_job
+        end
+      end
+
+      private
+
+      def fetch_previous_iteration_state
+        state = Sidekiq.redis { |conn| conn.hgetall("it-#{jid}") }
+
+        unless state.empty?
+          @executions = state["executions"].to_i
+          @cursor = Sidekiq.load_json(state["cursor"])
+          @times_interrupted = state["times_interrupted"].to_i
+          @total_time = state["total_time"].to_f
+        end
+      end
+
+      STATE_FLUSH_INTERVAL = 5 # seconds
+      STATE_TTL = 30 * 24 * 60 * 60 # 30 days
+
+      def iterate_with_enumerator(enumerator, arguments)
+        found_record = false
+        state_flushed_at = Time.now
+
+        enumerator.each do |object, cursor|
+          found_record = true
+          around_iteration do
+            each_iteration(object, *arguments)
+          end
+          @cursor = cursor
+          adjust_total_time
+
+          if Time.now - state_flushed_at >= STATE_FLUSH_INTERVAL || job_should_exit?
+            flush_state
+            state_flushed_at = Time.now
+          end
+
+          if job_should_exit?
+            return false
+          end
+        end
+
+        logger.debug("Enumerator found nothing to iterate!") unless found_record
+
+        true
+      end
+
+      def reenqueue_iteration_job
+        @times_interrupted += 1
+        flush_state
+        logger.debug { "Interrupting and re-enqueueing the job (cursor=#{cursor.inspect})" }
+
+        raise Interrupted
+      end
+
+      def adjust_total_time
+        @total_time += (Time.now - @start_time).round(3)
+      end
+
+      def assert_enumerator!(enum)
+        unless enum.is_a?(Enumerator)
+          raise ArgumentError, <<~MSG
+            #build_enumerator is expected to return Enumerator object, but returned #{enum.class}.
+            Example:
+              def build_enumerator(params, cursor:)
+                active_record_records_enumerator(
+                  Shop.find(params["shop_id"]).products,
+                  cursor: cursor
+                )
+              end
+          MSG
+        end
+      end
+
+      def job_should_exit?
+        max_job_runtime = self.class.get_sidekiq_options.dig("iteration", "max_job_runtime") ||
+          Sidekiq.default_configuration.dig(:iteration, :max_job_runtime)
+
+        ran_enough = max_job_runtime && @start_time && (Time.now - @start_time > max_job_runtime)
+        ran_enough || Sidekiq.stopping? || throttle?
+      end
+
+      def flush_state
+        key = "it-#{jid}"
+        state = {
+          "executions" => @executions,
+          "cursor" => Sidekiq.dump_json(@cursor),
+          "times_interrupted" => @times_interrupted,
+          "total_time" => @total_time
+        }
+
+        Sidekiq.redis do |conn|
+          conn.multi do |pipe|
+            pipe.hset(key, state)
+            pipe.expire(key, STATE_TTL)
+          end
+        end
+      end
+
+      def handle_completed(completed)
+        case completed
+        when nil, # someone aborted the job but wants to call the on_complete callback
+             true
+          true
+        when false
+          false
+        else
+          raise "Unexpected thrown value: #{completed.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/job/iterable.rb
+++ b/lib/sidekiq/job/iterable.rb
@@ -4,9 +4,9 @@ require_relative "iterable/enumerators"
 
 module Sidekiq
   module Job
-    module Iterable
-      class Interrupted < ::RuntimeError; end
+    class Interrupted < ::RuntimeError; end
 
+    module Iterable
       include Enumerators
 
       # @api private
@@ -24,6 +24,9 @@ module Sidekiq
           super
         end
       end
+
+      # @api private
+      attr_accessor :lifecycle
 
       # @api private
       def initialize
@@ -224,7 +227,7 @@ module Sidekiq
           Sidekiq.default_configuration.dig(:iteration, :max_job_runtime)
 
         ran_enough = max_job_runtime && @start_time && (Time.now - @start_time > max_job_runtime)
-        ran_enough || Sidekiq.stopping? || throttle?
+        ran_enough || lifecycle.stopping? || throttle?
       end
 
       def flush_state

--- a/lib/sidekiq/job/iterable/active_record_enumerator.rb
+++ b/lib/sidekiq/job/iterable/active_record_enumerator.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  module Job
+    module Iterable
+      # @api private
+      class ActiveRecordEnumerator
+        def initialize(relation, cursor: nil, **options)
+          @relation = relation
+          @cursor = cursor
+          @options = options
+        end
+
+        def records
+          Enumerator.new(-> { @relation.count }) do |yielder|
+            @relation.find_each(**@options, start: @cursor) do |record|
+              yielder.yield(record, record.id)
+            end
+          end
+        end
+
+        def batches
+          Enumerator.new(-> { @relation.count }) do |yielder|
+            @relation.find_in_batches(**@options, start: @cursor) do |batch|
+              yielder.yield(batch, batch.last.id)
+            end
+          end
+        end
+
+        def relations
+          Enumerator.new(-> { relations_size }) do |yielder|
+            # Convenience to use :batch_size for all the
+            # ActiveRecord batching methods.
+            options = @options.dup
+            options[:of] ||= options.delete(:batch_size)
+
+            @relation.in_batches(**options, start: @cursor) do |relation|
+              last_record = relation.last
+              yielder.yield(relation, last_record.id)
+            end
+          end
+        end
+
+        private
+
+        def relations_size
+          batch_size = @options[:batch_size] || 1000
+          (@relation.count + batch_size - 1) / batch_size # ceiling division
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/job/iterable/csv_enumerator.rb
+++ b/lib/sidekiq/job/iterable/csv_enumerator.rb
@@ -34,7 +34,10 @@ module Sidekiq
           filepath = @csv.path
           return unless filepath
 
-          count = `wc -l < #{filepath}`.strip.to_i
+          count = IO.popen(["wc", "-l", filepath]) do |out|
+            out.read.strip.to_i
+          end
+
           count -= 1 if @csv.headers
           count
         end

--- a/lib/sidekiq/job/iterable/csv_enumerator.rb
+++ b/lib/sidekiq/job/iterable/csv_enumerator.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  module Job
+    module Iterable
+      # @api private
+      class CsvEnumerator
+        def initialize(csv)
+          unless defined?(CSV) && csv.instance_of?(CSV)
+            raise ArgumentError, "CsvEnumerator.new takes CSV object"
+          end
+
+          @csv = csv
+        end
+
+        def rows(cursor:)
+          @csv.lazy
+            .each_with_index
+            .drop(cursor || 0)
+            .to_enum { count_of_rows_in_file }
+        end
+
+        def batches(cursor:, batch_size: 100)
+          @csv.lazy
+            .each_slice(batch_size)
+            .with_index
+            .drop(cursor || 0)
+            .to_enum { (count_of_rows_in_file.to_f / batch_size).ceil }
+        end
+
+        private
+
+        def count_of_rows_in_file
+          filepath = @csv.path
+          return unless filepath
+
+          count = `wc -l < #{filepath}`.strip.to_i
+          count -= 1 if @csv.headers
+          count
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/job/iterable/enumerators.rb
+++ b/lib/sidekiq/job/iterable/enumerators.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require_relative "active_record_enumerator"
+require_relative "csv_enumerator"
+require_relative "nested_enumerator"
+
+module Sidekiq
+  module Job
+    module Iterable
+      module Enumerators
+        # Builds Enumerator object from a given array, using +cursor+ as an offset.
+        #
+        # @param array [Array]
+        # @param cursor [Integer] offset to start iteration from
+        #
+        # @return [Enumerator]
+        #
+        # @example
+        #   array_enumerator(['build', 'enumerator', 'from', 'any', 'array'], cursor: cursor)
+        #
+        def array_enumerator(array, cursor:)
+          raise ArgumentError, "array must be an Array" unless array.is_a?(Array)
+
+          array.each_with_index.drop(cursor || 0).to_enum { array.size }
+        end
+
+        # Builds Enumerator from `ActiveRecord::Relation`.
+        # Each Enumerator tick moves the cursor one row forward.
+        #
+        # @param relation [ActiveRecord::Relation] relation to iterate
+        # @param cursor [Object] offset id to start iteration from
+        # @param options [Hash] additional options that will be passed to relevant
+        #   ActiveRecord batching methods
+        #
+        # @return [ActiveRecordEnumerator]
+        #
+        # @example
+        #   def build_enumerator(cursor:)
+        #     active_record_records_enumerator(User.all, cursor: cursor)
+        #   end
+        #
+        #   def each_iteration(user)
+        #     user.notify_about_something
+        #   end
+        #
+        def active_record_records_enumerator(relation, cursor:, **options)
+          ActiveRecordEnumerator.new(relation, cursor: cursor, **options).records
+        end
+
+        # Builds Enumerator from `ActiveRecord::Relation` and enumerates on batches of records.
+        # Each Enumerator tick moves the cursor `:batch_size` rows forward.
+        # @see #active_record_records_enumerator
+        #
+        # @example
+        #   def build_enumerator(product_id, cursor:)
+        #     active_record_batches_enumerator(
+        #       Comment.where(product_id: product_id).select(:id),
+        #       cursor: cursor,
+        #       batch_size: 100
+        #     )
+        #   end
+        #
+        #   def each_iteration(batch_of_comments, product_id)
+        #     comment_ids = batch_of_comments.map(&:id)
+        #     CommentService.call(comment_ids: comment_ids)
+        #   end
+        #
+        def active_record_batches_enumerator(relation, cursor:, **options)
+          ActiveRecordEnumerator.new(relation, cursor: cursor, **options).batches
+        end
+
+        # Builds Enumerator from `ActiveRecord::Relation` and enumerates on batches,
+        # yielding `ActiveRecord::Relation`s.
+        # @see #active_record_records_enumerator
+        #
+        # @example
+        #   def build_enumerator(product_id, cursor:)
+        #     active_record_relations_enumerator(
+        #       Product.find(product_id).comments,
+        #       cursor: cursor,
+        #       batch_size: 100,
+        #     )
+        #   end
+        #
+        #   def each_iteration(batch_of_comments, product_id)
+        #     # batch_of_comments will be a Comment::ActiveRecord_Relation
+        #     batch_of_comments.update_all(deleted: true)
+        #   end
+        #
+        def active_record_relations_enumerator(relation, cursor:, **options)
+          ActiveRecordEnumerator.new(relation, cursor: cursor, **options).relations
+        end
+
+        # Builds Enumerator from a CSV file.
+        #
+        # @param csv [CSV] an instance of CSV object
+        # @param cursor [Integer] offset to start iteration from
+        #
+        # @example
+        #   def build_enumerator(import_id, cursor:)
+        #     import = Import.find(import_id)
+        #     csv_enumerator(import.csv, cursor: cursor)
+        #   end
+        #
+        #   def each_iteration(csv_row)
+        #     # insert csv_row into database
+        #   end
+        #
+        def csv_enumerator(csv, cursor:)
+          CsvEnumerator.new(csv).rows(cursor: cursor)
+        end
+
+        # Builds Enumerator from a CSV file and enumerates on batches of records.
+        #
+        # @param csv [CSV] an instance of CSV object
+        # @param cursor [Integer] offset to start iteration from
+        # @option options :batch_size [Integer] (100) size of the batch
+        #
+        # @example
+        #   def build_enumerator(import_id, cursor:)
+        #     import = Import.find(import_id)
+        #     csv_batches_enumerator(import.csv, cursor: cursor)
+        #   end
+        #
+        #   def each_iteration(batch_of_csv_rows)
+        #     # ...
+        #   end
+        #
+        def csv_batches_enumerator(csv, cursor:, **options)
+          CsvEnumerator.new(csv).batches(cursor: cursor, **options)
+        end
+
+        # Builds Enumerator for nested iteration.
+        #
+        # @param enums [Array<Proc>] an Array of Procs, each should return an Enumerator.
+        #   Each proc from enums should accept the yielded items from the parent enumerators and the `cursor` as its arguments.
+        #   Each proc's `cursor` argument is its part from the `build_enumerator`'s `cursor` array.
+        # @param cursor [Array<Object>] array of offsets for each of the enums to start iteration from
+        #
+        # @example
+        #   def build_enumerator(cursor:)
+        #     nested_enumerator(
+        #       [
+        #         ->(cursor) { active_record_records_enumerator(Shop.all, cursor: cursor) },
+        #         ->(shop, cursor) { active_record_records_enumerator(shop.products, cursor: cursor) },
+        #         ->(_shop, product, cursor) { active_record_relations_enumerator(product.product_variants, cursor: cursor) }
+        #       ],
+        #       cursor: cursor
+        #     )
+        #   end
+        #
+        #   def each_iteration(product_variants_relation)
+        #     # do something
+        #   end
+        #
+        def nested_enumerator(enums, cursor:)
+          NestedEnumerator.new(enums, cursor: cursor).each
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/job/iterable/nested_enumerator.rb
+++ b/lib/sidekiq/job/iterable/nested_enumerator.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  module Job
+    module Iterable
+      # @api private
+      class NestedEnumerator
+        def initialize(enums, cursor: nil)
+          unless enums.all?(Proc)
+            raise ArgumentError, "enums must contain only procs/lambdas"
+          end
+
+          if cursor && enums.size != cursor.size
+            raise ArgumentError, "cursor should have one item per enum"
+          end
+
+          @enums = enums
+          @cursor = cursor || Array.new(enums.size)
+        end
+
+        def each(&block)
+          return to_enum unless block
+
+          iterate([], [], 0, &block)
+        end
+
+        private
+
+        def iterate(current_items, current_cursor, index, &block)
+          cursor = @cursor[index]
+          enum = @enums[index].call(*current_items, cursor)
+
+          enum.each do |item, cursor_value|
+            if index == @cursor.size - 1
+              yield item, current_cursor + [cursor_value]
+            else
+              iterate(current_items + [item], current_cursor + [cursor_value], index + 1, &block)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -116,7 +116,7 @@ module Sidekiq
     rescue Sidekiq::Shutdown => ey
       # ignore, will be pushed back onto queue during hard_shutdown
       raise ey
-    rescue Job::Iterable::Interrupted
+    rescue Job::Interrupted
       process_requeue(jobinst, jobstr)
       raise Skip
     rescue Exception => e
@@ -138,8 +138,9 @@ module Sidekiq
     private
 
     def process_requeue(jobinst, jobstr)
-      retry_backoff = jobinst.class.get_sidekiq_options.dig("iteration", "retry_backoff") ||
-        Sidekiq.default_configuration.dig(:iteration, :retry_backoff)
+      msg = Sidekiq.load_json(jobstr)
+      capsule = jobinst.lifecycle.capsule
+      retry_backoff = msg.dig("iteration", "retry_backoff") || capsule.config.dig(:iteration, :retry_backoff)
 
       redis do |conn|
         conn.zadd("schedule", retry_backoff, jobstr)

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -83,10 +83,7 @@ module Sidekiq
 
     def process_one(&block)
       @job = fetch
-      if @job
-        @job.lifecycle = self if @job.is_a?(Job::Iterable)
-        process(@job)
-      end
+      process(@job) if @job
       @job = nil
     end
 
@@ -143,6 +140,7 @@ module Sidekiq
                 klass = Object.const_get(job_hash["class"])
                 inst = klass.new
                 inst.jid = job_hash["jid"]
+                inst.lifecycle = self if inst.is_a?(Job::Iterable)
                 @retrier.local(inst, jobstr, queue) do
                   yield inst
                 end

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -58,6 +58,10 @@ module Sidekiq
       @thread.value if wait
     end
 
+    def stopping?
+      @done
+    end
+
     def start
       @thread ||= safe_thread("#{config.name}/processor", &method(:run))
     end
@@ -79,7 +83,10 @@ module Sidekiq
 
     def process_one(&block)
       @job = fetch
-      process(@job) if @job
+      if @job
+        @job.lifecycle = self if @job.is_a?(Job::Iterable)
+        process(@job)
+      end
       @job = nil
     end
 

--- a/test/fixtures/products.csv
+++ b/test/fixtures/products.csv
@@ -1,0 +1,12 @@
+shop_id,product_id,title
+1,101,Apple
+2,102,Banana
+3,103,Orange
+4,104,Cranberry
+5,105,Raspberry
+6,106,Kiwi
+7,107,Grapefruit
+8,108,Mango
+9,109,Watermelon
+10,110,Mellon
+11,111,Peach

--- a/test/iterable/active_record_enumerator_test.rb
+++ b/test/iterable/active_record_enumerator_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "csv"
+require "active_record"
+require "sidekiq"
+require_relative "../helper"
+require_relative "../dummy/config/environment"
+
+class Product < ActiveRecord::Base
+end
+
+describe Sidekiq::Job::Iterable::ActiveRecordEnumerator do
+  before(:all) do
+    Product.connection.create_table(:products, force: true)
+    products = [9, 1, 3, 2, 7, 6, 4, 5, 8, 10].map { |id| {id: id} }
+    Product.insert_all!(products)
+  end
+
+  describe "#records" do
+    it "yields every record with their cursor position" do
+      enum = build_enumerator.records
+      assert_equal Product.count, enum.size
+
+      products = Product.order(:id).take(3)
+      enum.first(3).each_with_index do |(record, cursor), index|
+        product = products[index]
+        assert_equal product, record
+        assert_equal product.id, cursor
+      end
+    end
+
+    it "does not yield anything if the relation is empty" do
+      enum = build_enumerator(relation: Product.none).records
+
+      assert_empty enum.to_a
+      assert_equal 0, enum.size
+    end
+
+    it "can be resumed" do
+      enum = build_enumerator(cursor: Product.second.id).records
+      assert_equal Product.count, enum.size
+
+      products = Product.order(:id).offset(1).take(3)
+      enum.first(3).each_with_index do |(record, cursor), index|
+        product = products[index]
+        assert_equal product, record
+        assert_equal product.id, cursor
+      end
+    end
+  end
+
+  describe "#batches" do
+    it "yields batches of records with the last record's cursor position" do
+      enum = build_enumerator.batches
+      assert_equal 10, enum.size
+
+      products = Product.order(:id).take(4).each_slice(2).to_a
+
+      enum.first(2).each_with_index do |(batch, cursor), index|
+        expected_batch = products[index]
+        expected_cursor = expected_batch.last.id
+        assert_equal expected_batch, batch
+        assert_equal expected_cursor, cursor
+      end
+    end
+
+    it "does not yield anything if the relation is empty" do
+      enum = build_enumerator(relation: Product.none).batches
+      assert_empty enum.to_a
+    end
+
+    it "can be resumed" do
+      enum = build_enumerator(cursor: Product.second.id).batches
+      assert_equal 10, enum.size
+
+      products = Product.order(:id).offset(1).take(4).each_slice(2).to_a
+
+      enum.first(2).each_with_index do |(batch, cursor), index|
+        expected_records = products[index]
+        expected_cursor = expected_records.last.id
+        assert_equal expected_records, batch
+        assert_equal expected_cursor, cursor
+      end
+    end
+  end
+
+  describe "#relations" do
+    it "yields relations with the last record's cursor position" do
+      enum = build_enumerator.relations
+      assert_equal 5, enum.size
+
+      product_batches = Product.order(:id).take(4).in_groups_of(2)
+
+      enum.first(2).each_with_index do |(relation, cursor), index|
+        assert_kind_of ActiveRecord::Relation, relation
+
+        expected_records = product_batches[index]
+        expected_cursor = expected_records.last.id
+        assert_equal expected_records, relation.to_a
+        assert_equal expected_cursor, cursor
+      end
+    end
+
+    it "yields unloaded relations" do
+      enum = build_enumerator.relations
+      relation, = enum.first
+
+      refute relation.loaded?
+    end
+
+    it "does not yield anything if the relation is empty" do
+      enum = build_enumerator(relation: Product.none).relations
+      assert_empty enum.to_a
+    end
+
+    it "can be resumed" do
+      enum = build_enumerator(cursor: Product.second.id).relations
+      assert_equal 5, enum.size
+
+      product_batches = Product.order(:id).offset(1).take(4).in_groups_of(2)
+
+      enum.first(2).each_with_index do |(relation, cursor), index|
+        assert_kind_of ActiveRecord::Relation, relation
+
+        expected_records = product_batches[index]
+        expected_cursor = expected_records.last.id
+        assert_equal expected_records, relation.to_a
+        assert_equal expected_cursor, cursor
+      end
+    end
+  end
+
+  private
+
+  def build_enumerator(relation: Product.all, batch_size: 2, cursor: nil)
+    Sidekiq::Job::Iterable::ActiveRecordEnumerator.new(relation, batch_size: batch_size, cursor: cursor)
+  end
+end

--- a/test/iterable/csv_enumerator_test.rb
+++ b/test/iterable/csv_enumerator_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "csv"
+require "sidekiq"
+require_relative "../helper"
+
+describe Sidekiq::Job::Iterable::CsvEnumerator do
+  it "raises if passed object is not a CSV" do
+    e = assert_raises(ArgumentError) do
+      build_enumerator([])
+    end
+    assert_equal "CsvEnumerator.new takes CSV object", e.message
+  end
+
+  describe "#rows" do
+    it "yields every record with their cursor position" do
+      enum = build_enumerator(products_csv).rows(cursor: nil)
+      assert_instance_of Enumerator::Lazy, enum
+
+      enum.each_with_index do |(element, cursor), index|
+        assert_equal [csv_rows[index], index], [element.fields, cursor]
+      end
+    end
+
+    it "can be resumed" do
+      enum = build_enumerator(products_csv).rows(cursor: 3)
+      assert_instance_of Enumerator::Lazy, enum
+
+      enum.each_with_index do |(element, cursor), index|
+        assert_equal [csv_rows[index + 3], index + 3], [element.fields, cursor]
+      end
+    end
+
+    it "returns size excluding headers" do
+      enum = build_enumerator(products_csv(headers: false)).rows(cursor: 0)
+      assert_equal 12, enum.size
+
+      enum = build_enumerator(products_csv(headers: true)).rows(cursor: 0)
+      assert_equal 11, enum.size
+    end
+
+    it "returns nil count for a CSV object from a String" do
+      csv_string = File.read("test/fixtures/products.csv")
+      enum = build_enumerator(CSV.new(csv_string)).rows(cursor: 0)
+      assert_nil enum.size
+    end
+
+    it "returns total size if resumed" do
+      enum = build_enumerator(products_csv).rows(cursor: 10)
+      assert_equal 11, enum.size
+    end
+  end
+
+  describe "#batches" do
+    it "yields every batch with their cursor position" do
+      enum = build_enumerator(products_csv).batches(batch_size: 3, cursor: nil)
+      assert_instance_of Enumerator::Lazy, enum
+
+      expected_values = csv_rows.each_slice(3).to_a
+      enum.each_with_index do |(element, cursor), index|
+        assert_equal [expected_values[index], index], [element.map(&:fields), cursor]
+      end
+    end
+
+    it "can be resumed" do
+      enum = build_enumerator(products_csv).batches(batch_size: 3, cursor: 2)
+      assert_instance_of Enumerator::Lazy, enum
+
+      expected_values = csv_rows.each_slice(3).drop(2).to_a
+      enum.each_with_index do |(element, cursor), index|
+        assert_equal [expected_values[index], index + 2], [element.map(&:fields), cursor]
+      end
+    end
+
+    it "returns size" do
+      enum = build_enumerator(products_csv).batches(batch_size: 2, cursor: 0)
+      assert_equal 6, enum.size
+
+      enum = build_enumerator(products_csv).batches(batch_size: 3, cursor: 0)
+      assert_equal 4, enum.size
+    end
+
+    it "returns total size if resumed" do
+      enum = build_enumerator(products_csv).batches(batch_size: 2, cursor: 5)
+      assert_equal 6, enum.size
+    end
+  end
+
+  private
+
+  def build_enumerator(csv)
+    Sidekiq::Job::Iterable::CsvEnumerator.new(csv)
+  end
+
+  def csv_rows
+    @csv_rows ||= products_csv.map(&:fields)
+  end
+
+  def products_csv(options = {})
+    CSV.open("test/fixtures/products.csv", converters: :integer, headers: true, **options)
+  end
+end

--- a/test/iterable/iterable_jobs.rb
+++ b/test/iterable/iterable_jobs.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+class SimpleIterableJob
+  include Sidekiq::Job
+  include Sidekiq::Job::Iterable
+
+  cattr_accessor :iterated_objects, default: []
+  cattr_accessor :on_start_called, default: 0
+  cattr_accessor :around_iteration_called, default: 0
+  cattr_accessor :on_resume_called, default: 0
+  cattr_accessor :on_shutdown_called, default: 0
+  cattr_accessor :on_complete_called, default: 0
+
+  def on_start
+    self.class.on_start_called += 1
+  end
+
+  def around_iteration
+    self.class.around_iteration_called += 1
+    yield
+  end
+
+  def on_resume
+    self.class.on_resume_called += 1
+  end
+
+  def on_shutdown
+    self.class.on_shutdown_called += 1
+  end
+
+  def on_complete
+    self.class.on_complete_called += 1
+  end
+end
+
+class MissingBuildEnumeratorJob < SimpleIterableJob
+  def each_iteration(*)
+  end
+end
+
+class JobWithBuildEnumeratorReturningArray < SimpleIterableJob
+  def build_enumerator(*)
+    []
+  end
+end
+
+class MissingEachIterationJob < SimpleIterableJob
+  def build_enumerator(cursor:)
+    array_enumerator([1, 2, 3], cursor: cursor)
+  end
+end
+
+class NilEnumeratorIterableJob < SimpleIterableJob
+  def build_enumerator(*)
+  end
+
+  def each_iteration(*)
+  end
+end
+
+class ArrayIterableJob < SimpleIterableJob
+  cattr_accessor :stop_after_iterations
+
+  def build_enumerator(cursor:)
+    @current_run_iterations = 0
+
+    array_enumerator((10..20).to_a, cursor: cursor)
+  end
+
+  def each_iteration(number)
+    self.class.iterated_objects << number
+    @current_run_iterations += 1
+  end
+
+  def throttle?
+    @current_run_iterations == stop_after_iterations
+  end
+end
+
+class ActiveRecordRecordsJob < SimpleIterableJob
+  def build_enumerator(cursor:)
+    active_record_records_enumerator(Product.all, cursor: cursor)
+  end
+
+  def each_iteration(record)
+    self.class.iterated_objects << record
+  end
+end
+
+class ActiveRecordBatchesJob < SimpleIterableJob
+  def build_enumerator(cursor:)
+    active_record_batches_enumerator(Product.all, cursor: cursor, batch_size: 3)
+  end
+
+  def each_iteration(batch)
+    self.class.iterated_objects << batch
+  end
+end
+
+class ActiveRecordRelationsJob < SimpleIterableJob
+  def build_enumerator(cursor:)
+    active_record_relations_enumerator(Product.all, cursor: cursor, batch_size: 3)
+  end
+
+  def each_iteration(relation)
+    self.class.iterated_objects << relation
+  end
+end
+
+class CsvIterableJob < SimpleIterableJob
+  def build_enumerator(cursor:)
+    csv = CSV.open("test/fixtures/products.csv", converters: :integer, headers: true)
+    csv_enumerator(csv, cursor: cursor)
+  end
+
+  def each_iteration(row)
+    self.class.iterated_objects << row
+  end
+end
+
+class CsvBatchesIterableJob < SimpleIterableJob
+  def build_enumerator(cursor:)
+    csv = CSV.open("test/fixtures/products.csv", converters: :integer, headers: true)
+    csv_batches_enumerator(csv, cursor: cursor, batch_size: 3)
+  end
+
+  def each_iteration(batch)
+    self.class.iterated_objects << batch
+  end
+end
+
+class IterableJobWithArguments < SimpleIterableJob
+  def build_enumerator(_one_arg, _another_arg, cursor:)
+    array_enumerator([0, 1], cursor: cursor)
+  end
+
+  def each_iteration(number, one_arg, another_arg)
+    self.class.iterated_objects << [number, one_arg, another_arg]
+  end
+end
+
+class EmptyEnumeratorJob < SimpleIterableJob
+  def build_enumerator(cursor:)
+    array_enumerator([], cursor: cursor)
+  end
+
+  def each_iteration(*)
+  end
+end
+
+class AbortingIterableJob < ArrayIterableJob
+  def each_iteration(*)
+    throw(:abort) if self.class.iterated_objects.size == 2
+    super
+  end
+end
+
+class LongRunningIterableJob < ArrayIterableJob
+  def each_iteration(*)
+    sleep(0.01)
+  end
+end
+
+class LongRunningCustomConfigIterableJob < ArrayIterableJob
+  sidekiq_options iteration: {max_job_runtime: 0.01}
+  def each_iteration(*)
+    sleep(0.01)
+  end
+end

--- a/test/iterable/iterable_jobs.rb
+++ b/test/iterable/iterable_jobs.rb
@@ -10,6 +10,7 @@ class SimpleIterableJob
   cattr_accessor :on_resume_called, default: 0
   cattr_accessor :on_shutdown_called, default: 0
   cattr_accessor :on_complete_called, default: 0
+  cattr_accessor :lifecycle
 
   def on_start
     self.class.on_start_called += 1

--- a/test/iterable/iterable_test.rb
+++ b/test/iterable/iterable_test.rb
@@ -1,0 +1,285 @@
+# frozen_string_literal: true
+
+require "csv"
+require "active_record"
+require "sidekiq"
+require "sidekiq/job_retry"
+require "sidekiq/capsule"
+require_relative "../helper"
+require_relative "iterable_jobs"
+require_relative "../dummy/config/environment"
+
+class Product < ActiveRecord::Base
+end
+
+describe Sidekiq::Job::Iterable do
+  before(:all) do
+    Product.connection.create_table(:products, force: true)
+    products = [9, 1, 3, 2, 7, 6, 4, 5, 8, 10].map { |id| {id: id} }
+    Product.insert_all!(products)
+  end
+
+  before do
+    @config = reset!
+
+    require "sidekiq/testing"
+    Sidekiq::Testing.fake!
+
+    SimpleIterableJob.descendants.each do |klass|
+      klass.iterated_objects = []
+      klass.on_start_called = 0
+      klass.around_iteration_called = 0
+      klass.on_resume_called = 0
+      klass.on_shutdown_called = 0
+      klass.on_complete_called = 0
+      klass.jobs.clear
+    end
+    ArrayIterableJob.stop_after_iterations = nil
+  end
+
+  after do
+    Sidekiq::Testing.disable!
+    Sidekiq::Queues.clear_all
+  end
+
+  it "raises when #build_enumerator method is missing" do
+    e = assert_raises(NotImplementedError) do
+      MissingBuildEnumeratorJob.perform_inline
+    end
+    assert_match(/must implement a '#build_enumerator' method/, e.message)
+  end
+
+  it "raises when #build_enumerator method returns non Enumerator" do
+    e = assert_raises(ArgumentError) do
+      JobWithBuildEnumeratorReturningArray.perform_inline
+    end
+    assert_match(/is expected to return Enumerator object, but returned Array/, e.message)
+  end
+
+  it "raises when #each_iteration method is missing" do
+    e = assert_raises(NotImplementedError) do
+      MissingEachIterationJob.perform_inline
+    end
+    assert_match(/must implement an '#each_iteration' method/, e.message)
+  end
+
+  it "cannot override #perform" do
+    e = assert_raises(RuntimeError) do
+      Class.new(SimpleIterableJob) do
+        def perform(*)
+        end
+      end
+    end
+    assert_match(/cannot redefine #perform/, e.message)
+  end
+
+  it "skips the job if #build_enumerator returned nil" do
+    output = capture_logging(@config, Logger::DEBUG) do
+      NilEnumeratorIterableJob.perform_inline
+    end
+    assert_includes(output, "'#build_enumerator' returned nil, skipping the job.")
+  end
+
+  it "iterates over arrays" do
+    ArrayIterableJob.perform_inline
+    numbers = ArrayIterableJob.iterated_objects
+    assert_equal (10..20).to_a, numbers
+  end
+
+  it "iterates over activerecord records" do
+    ActiveRecordRecordsJob.perform_inline
+    records = ActiveRecordRecordsJob.iterated_objects
+    assert_equal (1..10).to_a, records.pluck(:id)
+  end
+
+  it "iterates over activerecord batches" do
+    ActiveRecordBatchesJob.perform_inline
+
+    products = Product.order(:id).to_a
+    batches = ActiveRecordBatchesJob.iterated_objects
+    assert_equal [3, 3, 3, 1], batches.map(&:size)
+    assert_equal products, batches.flatten
+  end
+
+  it "iterates over activerecord relations" do
+    ActiveRecordRelationsJob.perform_inline
+
+    relations = ActiveRecordRelationsJob.iterated_objects
+    assert relations.all?(ActiveRecord::Relation)
+    assert relations.none?(&:loaded?)
+    assert_equal [3, 3, 3, 1], relations.map(&:count)
+
+    products = Product.order(:id).to_a
+    assert_equal products, relations.map(&:records).flatten
+  end
+
+  it "iterates over CSV rows" do
+    CsvIterableJob.perform_inline
+    rows = CsvIterableJob.iterated_objects
+    shop_ids = rows.map { |row| row.fields[0] }
+    assert_equal (1..11).to_a, shop_ids
+  end
+
+  it "iterates over CSV batches" do
+    CsvBatchesIterableJob.perform_inline
+    batches = CsvBatchesIterableJob.iterated_objects
+
+    assert_equal [3, 3, 3, 2], batches.map(&:size)
+    shop_ids = batches.flatten(1).map { |row| row.fields[0] }
+    assert_equal (1..11).to_a, shop_ids
+  end
+
+  it "supports jobs with arguments" do
+    IterableJobWithArguments.perform_inline("arg one", ["arg", "two"])
+
+    expected = [
+      [0, "arg one", ["arg", "two"]],
+      [1, "arg one", ["arg", "two"]]
+    ]
+    assert_equal expected, IterableJobWithArguments.iterated_objects
+  end
+
+  it "logs completion data" do
+    output = capture_logging(@config) do
+      ArrayIterableJob.perform_inline
+    end
+    assert_match(/Completed iterating/, output)
+  end
+
+  it "logs no iterations" do
+    output = capture_logging(@config, Logger::DEBUG) do
+      EmptyEnumeratorJob.perform_inline
+    end
+    assert_match(/Enumerator found nothing to iterate/, output)
+  end
+
+  it "aborting in #each_iteration will execute #on_complete callback" do
+    AbortingIterableJob.perform_inline
+
+    assert_equal 2, AbortingIterableJob.iterated_objects.size
+    assert_equal 1, AbortingIterableJob.on_complete_called
+    assert_equal 1, AbortingIterableJob.on_shutdown_called
+  end
+
+  it "can be resumed" do
+    jid = iterate_exact_times(ArrayIterableJob, 2)
+    assert_equal [10, 11], ArrayIterableJob.iterated_objects
+
+    previous_state = fetch_iteration_state(jid)
+    assert_equal 1, previous_state["executions"].to_i
+    assert_equal 1, Sidekiq.load_json(previous_state["cursor"])
+    assert_equal 1, previous_state["times_interrupted"].to_i
+    assert Float(previous_state["total_time"])
+
+    iterate_exact_times(ArrayIterableJob, 2, jid: jid)
+    assert_equal [10, 11, 11, 12], ArrayIterableJob.iterated_objects
+
+    previous_state = fetch_iteration_state(jid)
+    assert_equal 2, previous_state["executions"].to_i
+    assert_equal 2, Sidekiq.load_json(previous_state["cursor"])
+    assert_equal 2, previous_state["times_interrupted"].to_i
+
+    continue_iterating(ArrayIterableJob, jid: jid)
+    assert_equal (10..20).to_a, ArrayIterableJob.iterated_objects.uniq
+  end
+
+  it "calls iteration hooks" do
+    jid = iterate_exact_times(ArrayIterableJob, 2)
+
+    assert_equal 1, ArrayIterableJob.on_start_called
+    assert_equal 2, ArrayIterableJob.around_iteration_called
+    assert_equal 0, ArrayIterableJob.on_resume_called
+    assert_equal 1, ArrayIterableJob.on_shutdown_called
+    assert_equal 0, ArrayIterableJob.on_complete_called
+
+    iterate_exact_times(ArrayIterableJob, 2, jid: jid)
+
+    assert_equal 1, ArrayIterableJob.on_start_called
+    assert_equal 4, ArrayIterableJob.around_iteration_called
+    assert_equal 1, ArrayIterableJob.on_resume_called
+    assert_equal 2, ArrayIterableJob.on_shutdown_called
+    assert_equal 0, ArrayIterableJob.on_complete_called
+
+    continue_iterating(ArrayIterableJob, jid: jid)
+
+    assert_equal 1, ArrayIterableJob.on_start_called
+    assert_equal 13, ArrayIterableJob.around_iteration_called # 11 numbers + 2 restarts
+    assert_equal 2, ArrayIterableJob.on_resume_called
+    assert_equal 3, ArrayIterableJob.on_shutdown_called
+    assert_equal 1, ArrayIterableJob.on_complete_called
+  end
+
+  it "reschedules itself when sidekiq is stopping" do
+    jid = iterate_exact_times(ArrayIterableJob, 2)
+
+    assert_equal [10, 11], ArrayIterableJob.iterated_objects
+
+    Sidekiq.stub(:stopping?, true) do
+      iterate_exact_times(ArrayIterableJob, 2, jid: jid)
+      assert_equal [10, 11, 11], ArrayIterableJob.iterated_objects
+    end
+
+    continue_iterating(ArrayIterableJob, jid: jid)
+    assert_equal (10..20).to_a, ArrayIterableJob.iterated_objects.uniq
+  end
+
+  it "reschedules itself when the job runs longer than global :max_job_runtime" do
+    old = Sidekiq::Config::DEFAULTS[:iteration][:max_job_runtime]
+    Sidekiq::Config::DEFAULTS[:iteration][:max_job_runtime] = 0.01
+
+    assert_raises Sidekiq::Job::Iterable::Interrupted do
+      LongRunningCustomConfigIterableJob.perform_inline
+    end
+  ensure
+    Sidekiq::Config::DEFAULTS[:iteration][:max_job_runtime] = old
+  end
+
+  it "reschedules itself when the job runs longer than per-job :max_job_runtime" do
+    old = Sidekiq::Config::DEFAULTS[:iteration][:max_job_runtime]
+    Sidekiq::Config::DEFAULTS[:iteration][:max_job_runtime] = 10 # larger than per-job value
+
+    assert_raises Sidekiq::Job::Iterable::Interrupted do
+      LongRunningCustomConfigIterableJob.perform_inline
+    end
+  ensure
+    Sidekiq::Config::DEFAULTS[:iteration][:max_job_runtime] = old
+  end
+
+  private
+
+  def iterate_exact_times(job, count, jid: nil)
+    job.stop_after_iterations = count
+    if jid
+      job.set(jid: jid).perform_async
+    else
+      jid = job.perform_async
+    end
+
+    begin
+      handler.local(job.new, jobstr(job: job), "default") do
+        job.perform_one
+      end
+    rescue Sidekiq::JobRetry::Skip
+    end
+
+    jid
+  end
+
+  def continue_iterating(job, jid:)
+    job.stop_after_iterations = nil
+    job.set(jid: jid).perform_async
+    job.perform_one
+  end
+
+  def handler
+    @handler ||= Sidekiq::JobRetry.new(@config.default_capsule)
+  end
+
+  def jobstr(job:, **options)
+    Sidekiq.dump_json({"class" => job.name, "retry" => true}.merge(options))
+  end
+
+  def fetch_iteration_state(jid)
+    @config.redis { |conn| conn.hgetall("it-#{jid}") }
+  end
+end

--- a/test/iterable/nested_enumerator_test.rb
+++ b/test/iterable/nested_enumerator_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "csv"
+require "sidekiq"
+require_relative "../helper"
+
+describe Sidekiq::Job::Iterable::NestedEnumerator do
+  before do
+    @outer_items = [1, 2]
+    @inner_items = {1 => [3], 2 => [4, 5]}
+  end
+
+  it "accepts only callables as enums" do
+    e = assert_raises(ArgumentError) do
+      build_enumerator(outer: [[1, 2, 3].each])
+    end
+    assert_equal "enums must contain only procs/lambdas", e.message
+  end
+
+  it "raises when cursor is not of the same size as enums" do
+    e = assert_raises(ArgumentError) do
+      build_enumerator(cursor: [0])
+    end
+    assert_equal "cursor should have one item per enum", e.message
+  end
+
+  it "yields enumerator when called without a block" do
+    enum = build_enumerator
+    assert_kind_of Enumerator, enum
+    assert_nil enum.size
+  end
+
+  it "yields every nested record with their cursor position" do
+    enum = build_enumerator
+    expected = [
+      [3, [0, 0]], # in the format of [item, cursor]
+      [4, [1, 0]],
+      [5, [1, 1]]
+    ]
+
+    enum.each_with_index do |(item, cursor), index|
+      expected_item, expected_cursor = expected[index]
+      assert_equal expected_item, item
+      assert_equal expected_cursor, cursor
+    end
+  end
+
+  it "can be resumed" do
+    expected = [
+      [3, [0, 0]],
+      [4, [1, 0]],
+      [5, [1, 1]]
+    ]
+
+    expected.each_with_index do |(item, cursor), index|
+      enum = build_enumerator(cursor: cursor)
+      assert_equal [item, cursor], enum.next
+      assert_equal(expected[index + 1], enum.next) if index != expected.size - 1
+    end
+  end
+
+  it "does not yield anything if contains empty enum" do
+    enum = ->(_item, _cursor) { [].each }
+    enum = build_enumerator(inner: enum)
+    assert_empty enum.to_a
+  end
+
+  it "works with single level nesting" do
+    enum = build_enumerator(inner: nil)
+    expected = [[1, 0], [2, 1]]
+
+    enum.each_with_index do |(item, cursor), index|
+      expected_item, expected_cursor = expected[index]
+      assert_equal expected_item, item
+      assert_equal [expected_cursor], cursor
+    end
+  end
+
+  private
+
+  def build_enumerator(
+    outer: ->(cursor) { @outer_items.each_with_index.drop(cursor || 0) },
+    inner: ->(item, cursor) { @inner_items[item].each_with_index.drop(cursor || 0) },
+    cursor: nil
+  )
+    Sidekiq::Job::Iterable::NestedEnumerator.new([outer, inner].compact, cursor: cursor).each
+  end
+end


### PR DESCRIPTION
This is a native implementation of the https://github.com/fatkodima/sidekiq-iteration pattern.
Closes https://github.com/fatkodima/sidekiq-iteration/issues/6.

At a high level, the API will look something like:
```ruby
class NotifyUsersJob
  include Sidekiq::Job
  include Sidekiq::Job::Iterable

  def build_enumerator(cursor:)
    active_record_records_enumerator(User.all, cursor: cursor)
  end

  def each_iteration(user)
    user.notify_about_something
  end
end
```