### PR TITLE
Update example config

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,23 +1,29 @@
 # Sample configuration file for Sidekiq.
+#
 # Options here can still be overridden by cmd line args.
-# Place this file at config/sidekiq.yml and Sidekiq will
-# pick it up automatically.
+# Place this file at config/sidekiq.yml and Sidekiq will pick it up automatically.
 ---
-:verbose: false
-:concurrency: 10
-:timeout: 25
+# :verbose: false
+# :timeout: 25
 
-# Sidekiq will run this file through ERB when reading it so you can
-# even put in dynamic logic, like a host-specific queue.
+# Raising concurrency can cause CPU overload. For example, Heroku's basic dynos have very little CPU compared to modern servers.
+# :concurrency: 5
+
+# Concurrency can be overridden based on environment as well.
+# production:
+#   :concurrency: 5
+# staging:
+#   :concurrency: 5
+
+# Sidekiq will run this file through ERB when reading it so you can even put in dynamic logic, like a host-specific queue.
 # http://www.mikeperham.com/2013/11/13/advanced-sidekiq-host-specific-queues/
 :queues:
   - critical
   - default
   - <%= `hostname`.strip %>
+  - mailers
+  - active_storage_analysis
+  - active_storage_purge
+  - action_mailbox_routing
+  - action_mailbox_incineration
   - low
-
-# you can override concurrency based on environment
-production:
-  :concurrency: 25
-staging:
-  :concurrency: 15


### PR DESCRIPTION
This updates the example config to use default values for most things (like concurrency) and provide examples of how to customize.

It also includes some of the Rails default job queues for a more complete example.