### PR TITLE
New registration API for web extensions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,12 +5,13 @@
 HEAD (7.3.0)
 ----------
 
-- Allow `Sidekiq::Limiter.redis` to use Redis Cluster [#6288]
-- Adjust CSP to disallow inline styling and scripts within the Web UI [#6270]
-  This should make Sidekiq immune to future XSS attacks. 3rd party extensions
-  will need to adjust their web assets accordingly.
+- **SECURITY** The Web UI no longer allows extensions to use `<script>`.
+  Adjust CSP to disallow inline scripts within the Web UI. Please see
+  `examples/webui-ext` for how to register Web UI extensions and use
+  dynamic CSS and JS. This will make Sidekiq immune to XSS attacks. [#6270]
 - Add config option, `:skip_default_job_logging` to disable Sidekiq's default
   start/finish job logging. [#6200]
+- Allow `Sidekiq::Limiter.redis` to use Redis Cluster [#6288]
 
 7.2.4
 ----------

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,16 @@
 
 [Sidekiq Changes](https://github.com/sidekiq/sidekiq/blob/main/Changes.md) | [Sidekiq Pro Changes](https://github.com/sidekiq/sidekiq/blob/main/Pro-Changes.md) | [Sidekiq Enterprise Changes](https://github.com/sidekiq/sidekiq/blob/main/Ent-Changes.md)
 
+HEAD (7.3.0)
+----------
+
+- Allow `Sidekiq::Limiter.redis` to use Redis Cluster [#6288]
+- Adjust CSP to disallow inline styling and scripts within the Web UI [#6270]
+  This should make Sidekiq immune to future XSS attacks. 3rd party extensions
+  will need to adjust their web assets accordingly.
+- Add config option, `:skip_default_job_logging` to disable Sidekiq's default
+  start/finish job logging. [#6200]
+
 7.2.4
 ----------
 

--- a/examples/webui-ext/lib/sidekiq-redis_info.rb
+++ b/examples/webui-ext/lib/sidekiq-redis_info.rb
@@ -1,0 +1,14 @@
+require "sidekiq"
+
+module SidekiqExt
+  class RedisInfo
+    include Enumerable
+    def initialize
+      @info = Sidekiq.default_configuration.redis_info
+    end
+
+    def each(&block)
+      @info.each(&block)
+    end
+  end
+end

--- a/examples/webui-ext/lib/sidekiq-redis_info/web.rb
+++ b/examples/webui-ext/lib/sidekiq-redis_info/web.rb
@@ -4,8 +4,6 @@ require "sidekiq/web"
 class SidekiqExt::RedisInfo::Web
   ROOT = File.expand_path("../../web", File.dirname(__FILE__))
   VIEWS = File.expand_path("views", ROOT)
-  ASSETS = File.expand_path("assets", ROOT)
-  LOCALES = File.expand_path("locales", ROOT)
 
   def self.registered(app)
     app.get "/redis_info" do
@@ -24,15 +22,11 @@ end
 # and provide localizations for any strings in your extension.
 
 Sidekiq::Web.register(SidekiqExt::RedisInfo::Web,
-  tab: "Redis",              # The name on your Tab
-  index: "redis_info",       # The path to the root page of your extension within the Web UI, usually "/sidekiq/" + index
-  locale_dir: SidekiqExt::RedisInfo::Web::LOCALES) do |webapp|  # optional, if you have strings you wish to i18n
-  webapp.middlewares << [[
-    ::Rack::Static, {
-      urls: ["/redis_info/css", "/redis_info/js"],
-      root: SidekiqExt::RedisInfo::Web::ASSETS,
-      header_rules: [[:all, {Rack::CACHE_CONTROL => "private, max-age=86400"}]],
-      cascade: true
-    }
-  ], nil]
+  name: "redis_info",
+  tab: ["Redis"],              # The name on your Tab(s)
+  index: ["redis_info"],       # The path to the root page(s) of your extension within the Web UI, usually "/sidekiq/" + index
+  root_dir: SidekiqExt::RedisInfo::Web::ROOT,
+  asset_paths: ["css", "js"]   # Paths within {root}/assets/{name} to serve static assets
+) do |app|
+  # you can add your own middleware or additional settings here
 end

--- a/examples/webui-ext/lib/sidekiq-redis_info/web.rb
+++ b/examples/webui-ext/lib/sidekiq-redis_info/web.rb
@@ -1,0 +1,38 @@
+require "sidekiq-redis_info"
+require "sidekiq/web"
+
+class SidekiqExt::RedisInfo::Web
+  ROOT = File.expand_path("../../web", File.dirname(__FILE__))
+  VIEWS = File.expand_path("views", ROOT)
+  ASSETS = File.expand_path("assets", ROOT)
+  LOCALES = File.expand_path("locales", ROOT)
+
+  def self.registered(app)
+    app.get "/redis_info" do
+      @info = SidekiqExt::RedisInfo.new
+      erb(:redis_info, views: VIEWS)
+    end
+  end
+end
+
+# DEPRECATED --- Old way to register
+# Sidekiq::Web.register(SidekiqExt::RedisInfo::Web)
+# Sidekiq::Web.tabs["Redis"] = "redis_info"
+
+# NEW API IN 7.3.0
+# This new way allows you to serve your own static assets
+# and provide localizations for any strings in your extension.
+
+Sidekiq::Web.register(SidekiqExt::RedisInfo::Web,
+  tab: "Redis",              # The name on your Tab
+  index: "redis_info",       # The path to the root page of your extension within the Web UI, usually "/sidekiq/" + index
+  locale_dir: SidekiqExt::RedisInfo::Web::LOCALES) do |webapp|  # optional, if you have strings you wish to i18n
+  webapp.middlewares << [[
+    ::Rack::Static, {
+      urls: ["/redis_info/css", "/redis_info/js"],
+      root: SidekiqExt::RedisInfo::Web::ASSETS,
+      header_rules: [[:all, {Rack::CACHE_CONTROL => "private, max-age=86400"}]],
+      cascade: true
+    }
+  ], nil]
+end

--- a/examples/webui-ext/readme.md
+++ b/examples/webui-ext/readme.md
@@ -1,0 +1,53 @@
+# Web UI Extensions in Sidekiq 7.3 and 8.0
+
+This is an example of how to extend Sidekiq's Web UI to add your own tab.
+
+## Initialization
+
+The Ruby code for your extension goes in `lib/` like any normal Rubygem.
+When the user includes the `my-gem` gem within their bundle, Bundler will call `require "my-gem"` which corresponds to `lib/my-gem.rb` in your project.
+This file should **not** require any web code or assets because you don't know if you're running within a Sidekiq process or a Web process.
+
+> Don't require your web extensions in Sidekiq's initializer. This is a common mistake.
+
+Your web extension should be activated by the user calling `require "my-gem/web"` in Rails' `config/routes.rb` as that guarantees we are in a Web process.
+
+## Registration
+
+Your Web extension must register itself with Sidekiq::Web to appear in the Sidekiq UI.
+See `lib/sidekiq-redis_info/web.rb` for a full-featured example.
+
+## Content Security
+
+Sidekiq 7.3 and 8.0 explicitly lock down the Web UI to prevent XSS and malicious content injection.
+In Sidekiq 7.3, the Web UI no longer allows ěmbedding JavaScript directly on the HTML page via
+`<script>...code...</script>`. In Sidekiq 8.0, inline styling via `<style>...css...</style>` will not work.
+
+### JavaScript
+
+JavaScript must be packaged in predefined .js files with a per-request nonce that proves it was rendered by the webapp:
+
+```html
+<script type="text/javascript" src="<%= root_path %>my-gem/js/somefile.js" nonce="<%= csp_nonce %>"></script>
+```
+
+### CSS
+
+Static CSS must be linked with the nonce:
+
+```
+<link href="<%= root_path %>redis_info/css/somefile.css" media="screen" rel="stylesheet" type="text/css" nonce="<%= csp_nonce %>" />
+```
+
+You can dynamically adjust styling with javascript:
+
+```
+# will not work
+<div style="width: 12%">
+
+# will work
+<div class="foobar" data-width="12">
+
+# in an included .js file
+document.querySelectorAll('.foobar').forEach(bar => { bar.style.width = bar.dataset.width + "%"})
+```

--- a/examples/webui-ext/readme.md
+++ b/examples/webui-ext/readme.md
@@ -5,22 +5,22 @@ This is an example of how to extend Sidekiq's Web UI to add your own tab.
 ## Initialization
 
 The Ruby code for your extension goes in `lib/` like any normal Rubygem.
-When the user includes the `my-gem` gem within their bundle, Bundler will call `require "my-gem"` which corresponds to `lib/my-gem.rb` in your project.
+When the user includes the `my_gem` gem within their bundle, Bundler will call `require "my_gem"` which corresponds to `lib/my_gem.rb` in your project.
 This file should **not** require any web code or assets because you don't know if you're running within a Sidekiq process or a Web process.
 
 > Don't require your web extensions in Sidekiq's initializer. This is a common mistake.
 
-Your web extension should be activated by the user calling `require "my-gem/web"` in Rails' `config/routes.rb` as that guarantees we are in a Web process.
+Your web extension should be activated by the user calling `require "my_gem/web"` in Rails' `config/routes.rb` as that guarantees we are in a Web process. TODO usage in other web frameworks?
 
 ## Registration
 
 Your Web extension must register itself with Sidekiq::Web to appear in the Sidekiq UI.
-See `lib/sidekiq-redis_info/web.rb` for a full-featured example.
+See `lib/sidekiq-redis_info/web.rb` for an example.
 
 ## Content Security
 
 Sidekiq 7.3 and 8.0 explicitly lock down the Web UI to prevent XSS and malicious content injection.
-In Sidekiq 7.3, the Web UI no longer allows ěmbedding JavaScript directly on the HTML page via
+In Sidekiq 7.3, the Web UI no longer allows embedding JavaScript directly on the HTML page via
 `<script>...code...</script>`. In Sidekiq 8.0, inline styling via `<style>...css...</style>` will not work.
 
 ### JavaScript
@@ -28,7 +28,13 @@ In Sidekiq 7.3, the Web UI no longer allows ěmbedding JavaScript directly on th
 JavaScript must be packaged in predefined .js files with a per-request nonce that proves it was rendered by the webapp:
 
 ```html
-<script type="text/javascript" src="<%= root_path %>my-gem/js/somefile.js" nonce="<%= csp_nonce %>"></script>
+<script type="text/javascript" src="<%= root_path %>my_gem/js/somefile.js" nonce="<%= csp_nonce %>"></script>
+```
+
+Sidekiq provides a `script_tag` to handle these details.
+
+```erb
+<%= script_tag "my_gem/js/somefile.js" %>
 ```
 
 ### CSS
@@ -36,7 +42,7 @@ JavaScript must be packaged in predefined .js files with a per-request nonce tha
 Static CSS must be linked with the nonce:
 
 ```
-<link href="<%= root_path %>redis_info/css/somefile.css" media="screen" rel="stylesheet" type="text/css" nonce="<%= csp_nonce %>" />
+<link href="<%= root_path %>my_gem/css/somefile.css" media="screen" rel="stylesheet" type="text/css" nonce="<%= csp_nonce %>" />
 ```
 
 You can dynamically adjust styling with javascript:
@@ -50,4 +56,10 @@ You can dynamically adjust styling with javascript:
 
 # in an included .js file
 document.querySelectorAll('.foobar').forEach(bar => { bar.style.width = bar.dataset.width + "%"})
+```
+
+Sidekiq provides a `style_tag` to handle these details.
+
+```erb
+<%= style_tag "my_gem/css/somefile.css" %>
 ```

--- a/examples/webui-ext/sidekiq-redis_info.gemspec
+++ b/examples/webui-ext/sidekiq-redis_info.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "sidekiq-redis_info"
+  spec.version = "1.0"
+  spec.authors = ["Mike Perham"]
+  spec.email = ["mike@perham.net"]
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 2.6.0"
+  spec.summary = spec.description = "sidekiq example"
+  spec.homepage = "https://sidekiq.org"
+
+  spec.metadata["allowed_push_host"] = "NONE"
+  spec.metadata["homepage_uri"] = spec.homepage
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+    end
+  end
+  spec.require_paths = ["lib"]
+end

--- a/examples/webui-ext/web/assets/redis_info/css/ext.css
+++ b/examples/webui-ext/web/assets/redis_info/css/ext.css
@@ -1,0 +1,7 @@
+.keys {
+  color: green;
+}
+
+.values {
+  color: purple;
+}

--- a/examples/webui-ext/web/assets/redis_info/js/ext.js
+++ b/examples/webui-ext/web/assets/redis_info/js/ext.js
@@ -1,0 +1,1 @@
+document.querySelectorAll('.keys').forEach(col => { col.style.width = col.dataset.width + "%"})

--- a/examples/webui-ext/web/locales/en.yml
+++ b/examples/webui-ext/web/locales/en.yml
@@ -1,0 +1,4 @@
+en:
+  Redis: Redis
+  Key: Key
+  Value: Values

--- a/examples/webui-ext/web/views/redis_info.erb
+++ b/examples/webui-ext/web/views/redis_info.erb
@@ -1,4 +1,4 @@
-<link href="<%= root_path %>redis_info/css/ext.css" media="screen" rel="stylesheet" type="text/css" nonce="<%= csp_nonce %>" />
+<%= style_tag "redis_info/css/ext.css" %>
 
 <div class="header-container">
   <h1><%= t('Redis') %></h1>
@@ -21,4 +21,5 @@
   </table>
 </div>
 
-<script type="text/javascript" src="<%= root_path %>redis_info/js/ext.js" nonce="<%= csp_nonce %>"></script>
+<%= script_tag "redis_info/js/ext.js" %>
+<%= script_tag "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js", integrity: "sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz", crossorigin: "anonymous" %>

--- a/examples/webui-ext/web/views/redis_info.erb
+++ b/examples/webui-ext/web/views/redis_info.erb
@@ -1,0 +1,24 @@
+<link href="<%= root_path %>redis_info/css/ext.css" media="screen" rel="stylesheet" type="text/css" nonce="<%= csp_nonce %>" />
+
+<div class="header-container">
+  <h1><%= t('Redis') %></h1>
+</div>
+
+<div class="table_container">
+  <table class="table table-hover table-bordered table-striped table-condensed">
+    <thead>
+      <th class="keys" data-width="25"><%= t('Key') %></th>
+      <th class="values"><%= t('Value') %></th>
+    </thead>
+    <tbody>
+      <% @info.each do |k, v| %>
+      <tr>
+        <td><%= h k %></td>
+        <td><%= h v %></td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<script type="text/javascript" src="<%= root_path %>redis_info/js/ext.js" nonce="<%= csp_nonce %>"></script>

--- a/examples/webui-ext/web/views/redis_info.erb
+++ b/examples/webui-ext/web/views/redis_info.erb
@@ -22,4 +22,3 @@
 </div>
 
 <%= script_tag "redis_info/js/ext.js" %>
-<%= script_tag "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js", integrity: "sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz", crossorigin: "anonymous" %>

--- a/lib/sidekiq/redis_client_adapter.rb
+++ b/lib/sidekiq/redis_client_adapter.rb
@@ -64,6 +64,13 @@ module Sidekiq
       opts = client_opts(options)
       @config = if opts.key?(:sentinels)
         RedisClient.sentinel(**opts)
+      elsif opts.key?(:nodes)
+        # Sidekiq does not support Redis clustering but Sidekiq Enterprise's
+        # rate limiters are cluster-safe so we can scale to millions
+        # of rate limiters using a Redis cluster. This requires the
+        # `redis-cluster-client` gem.
+        # Sidekiq::Limiter.redis = { nodes: [...] }
+        RedisClient.cluster(**opts)
       else
         RedisClient.config(**opts)
       end

--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -15,6 +15,10 @@ module Sidekiq
         logger&.info { "Sidekiq #{Sidekiq::VERSION} connecting to Redis with options #{scrub(symbolized_options)}" }
 
         raise "Sidekiq 7+ does not support Redis protocol 2" if symbolized_options[:protocol] == 2
+
+        safe = !!symbolized_options.delete(:cluster_safe)
+        raise ":nodes not allowed, Sidekiq is not safe to run on Redis Cluster" if !safe && symbolized_options.key?(:nodes)
+
         size = symbolized_options.delete(:size) || 5
         pool_timeout = symbolized_options.delete(:pool_timeout) || 1
         pool_name = symbolized_options.delete(:pool_name)

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -139,10 +139,49 @@ module Sidekiq
       send(:"#{attribute}=", value)
     end
 
-    # TODO tab and index will be mandatory in 8.0
-    def self.register(extension, tab: nil, index: nil, asset_dir: nil, locale_dir: nil)
-      tabs[tab] = index if tab && index
-      locales << locale_dir if locale_dir
+    # Register a class as a Sidekiq Web UI extension. The class should
+    # provide one or more tabs which map to an index route. Options:
+    #
+    # @param extension [Class] Class which contains the HTTP actions, required
+    # @param name [String] the name of the extension, used to namespace assets
+    # @param tab [String | Array] labels(s) of the UI tabs
+    # @param index [String | Array] index route(s) for each tab
+    # @param root_dir [String] directory location to find assets, locales and views, typically `web/` within the gemfile
+    # @param asset_paths [Array] one or more directories under {root}/assets/{name} to be publicly served, e.g. ["js", "css", "img"]
+    # @param cache_for [Integer] amount of time to cache assets for, default one day
+    #
+    # TODO name, tab and index will be mandatory in 8.0
+    #
+    # Web extensions will have a root `web/` directory with `locales/`, `assets/`
+    # and `views/` subdirectories.
+    def self.register(extension, name: nil, tab: nil, index: nil, root_dir: nil, cache_for: 86400, asset_paths: nil)
+      tab = Array(tab)
+      index = Array(index)
+      tab.zip(index).each do |tab, index|
+        tabs[tab] = index
+      end
+      if root_dir
+        locdir = File.join(root_dir, "locales")
+        locales << locdir if File.directory?(locdir)
+
+        if asset_paths && name
+          # if you have {root}/assets/{name}/js/scripts.js
+          # and {root}/assets/{name}/css/styles.css
+          # you would pass in:
+          #   asset_paths: ["js", "css"]
+          # See script_tag and style_tag in web/helpers.rb
+          assdir = File.join(root_dir, "assets")
+          assurls = Array(asset_paths).map { |x| "/#{name}/#{x}" }
+          assetprops = {
+            urls: assurls,
+            root: assdir,
+            cascade: true
+          }
+          assetprops[:header_rules] = [[:all, {Rack::CACHE_CONTROL => "private, max-age=#{cache_for.to_i}"}]] if cache_for
+          middlewares << [[Rack::Static, assetprops], nil]
+        end
+      end
+
       yield self if block_given?
       extension.registered(WebApplication)
     end

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -139,7 +139,11 @@ module Sidekiq
       send(:"#{attribute}=", value)
     end
 
-    def self.register(extension)
+    # TODO tab and index will be mandatory in 8.0
+    def self.register(extension, tab: nil, index: nil, asset_dir: nil, locale_dir: nil)
+      tabs[tab] = index if tab && index
+      locales << locale_dir if locale_dir
+      yield self if block_given?
       extension.registered(WebApplication)
     end
 
@@ -157,7 +161,9 @@ module Sidekiq
           root: ASSETS,
           cascade: true,
           header_rules: rules
-        m.each { |middleware, block| use(*middleware, &block) }
+        m.each do |middleware, block|
+          use(*middleware, &block)
+        end
         use Sidekiq::Web::CsrfProtection unless $TESTING
         run WebApplication.new(klass)
       end

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -148,7 +148,7 @@ module Sidekiq
     # @param index [String | Array] index route(s) for each tab
     # @param root_dir [String] directory location to find assets, locales and views, typically `web/` within the gemfile
     # @param asset_paths [Array] one or more directories under {root}/assets/{name} to be publicly served, e.g. ["js", "css", "img"]
-    # @param cache_for [Integer] amount of time to cache assets for, default one day
+    # @param cache_for [Integer] amount of time to cache assets, default one day
     #
     # TODO name, tab and index will be mandatory in 8.0
     #
@@ -200,9 +200,7 @@ module Sidekiq
           root: ASSETS,
           cascade: true,
           header_rules: rules
-        m.each do |middleware, block|
-          use(*middleware, &block)
-        end
+        m.each { |middleware, block| use(*middleware, &block) }
         use Sidekiq::Web::CsrfProtection unless $TESTING
         run WebApplication.new(klass)
       end

--- a/lib/sidekiq/web/action.rb
+++ b/lib/sidekiq/web/action.rb
@@ -45,9 +45,10 @@ module Sidekiq
     end
 
     def erb(content, options = {})
+      views = options[:views] || Web.settings.views
       if content.is_a? Symbol
         unless respond_to?(:"_erb_#{content}")
-          src = ERB.new(File.read("#{Web.settings.views}/#{content}.erb")).src
+          src = ERB.new(File.read("#{views}/#{content}.erb")).src
           WebAction.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def _erb_#{content}
               #{src}

--- a/lib/sidekiq/web/action.rb
+++ b/lib/sidekiq/web/action.rb
@@ -45,9 +45,9 @@ module Sidekiq
     end
 
     def erb(content, options = {})
-      views = options[:views] || Web.settings.views
       if content.is_a? Symbol
         unless respond_to?(:"_erb_#{content}")
+          views = options[:views] || Web.settings.views
           src = ERB.new(File.read("#{views}/#{content}.erb")).src
           WebAction.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def _erb_#{content}

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -6,8 +6,50 @@ require "yaml"
 require "cgi"
 
 module Sidekiq
-  # This is not a public API
+  # This is not a public API for applications to use.
+  # These methods are available to pages within the Web UI and UI extensions.
   module WebHelpers
+    def style_tag(location, **kwargs)
+      global = location.match?(/:\/\//)
+      location = root_path + location if !global && !location.start_with?(root_path)
+      attrs = {
+        type: "text/css",
+        media: "screen",
+        rel: "stylesheet",
+        nonce: csp_nonce,
+        href: location
+      }
+      html_tag(:link, attrs.merge(kwargs))
+    end
+
+    def script_tag(location, **kwargs)
+      global = location.match?(/:\/\//)
+      location = root_path + location if !global && !location.start_with?(root_path)
+      attrs = {
+        type: "text/javascript",
+        nonce: csp_nonce,
+        src: location
+      }
+      html_tag(:script, attrs.merge(kwargs)) {}
+    end
+
+    private def html_tag(tagname, attrs)
+      s = "<#{tagname}"
+      attrs.each_pair do |k, v|
+        next unless v
+        s << " #{k}=\"#{v}\""
+      end
+      if block_given?
+        s << ">"
+        yield s
+        s << "</#{tagname}>"
+      else
+        s << " />"
+      end
+      puts s
+      s
+    end
+
     def strings(lang)
       @strings ||= {}
 

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -48,7 +48,6 @@ module Sidekiq
       else
         s << " />"
       end
-      puts s
       s
     end
 

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -6,7 +6,7 @@ require "yaml"
 require "cgi"
 
 module Sidekiq
-  # This is not a public API for applications to use.
+  # These are not public APIs for applications to use.
   # These methods are available to pages within the Web UI and UI extensions.
   module WebHelpers
     def style_tag(location, **kwargs)

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -6,8 +6,8 @@ require "yaml"
 require "cgi"
 
 module Sidekiq
-  # These are not public APIs for applications to use.
   # These methods are available to pages within the Web UI and UI extensions.
+  # They are not public APIs for applications to use.
   module WebHelpers
     def style_tag(location, **kwargs)
       global = location.match?(/:\/\//)
@@ -33,6 +33,8 @@ module Sidekiq
       html_tag(:script, attrs.merge(kwargs)) {}
     end
 
+    # NB: keys and values are not escaped; do not allow user input
+    # in the attributes
     private def html_tag(tagname, attrs)
       s = "<#{tagname}"
       attrs.each_pair do |k, v|

--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -15,3 +15,5 @@ gem "sidekiq", path: ".."
 gem "sqlite3"
 
 gem "after_commit_everywhere"
+
+gem "sidekiq-redis_info", path: "../examples/webui-ext"

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -2,6 +2,7 @@
 ENV["SIDEKIQ_WEB_TESTING"] = "1"
 
 require "sidekiq/web"
+require "sidekiq-redis_info/web"
 Sidekiq::Web.app_url = "/"
 
 Rails.application.routes.draw do


### PR DESCRIPTION
In order to lock down JS and CSS for better security, we need to provide a first-class API for web extensions so they can opt into better asset security while maintaining compatibility with existing versions.

Please see the content under `examples/webui-ext` and specifically the new `register` API:

```ruby
# DEPRECATED --- Old way to register
# Sidekiq::Web.register(SidekiqExt::RedisInfo::Web)
# Sidekiq::Web.tabs["Redis"] = "redis_info"

# NEW API IN 7.3.0
# This new way allows you to serve your own static assets
# and provide localizations for any strings in your extension.

Sidekiq::Web.register(SidekiqExt::RedisInfo::Web,
  name: "redis_info",
  tab: ["Redis"],              # The name on your Tab(s)
  index: ["redis_info"],       # The path to the root page(s) of your extension within the Web UI, usually "/sidekiq/" + index
  root_dir: SidekiqExt::RedisInfo::Web::ROOT, # root directory for all web ui content
  asset_paths: ["css", "js"],  # Paths within {root}/assets/{name} to serve static assets
  cache_for: 86400            # Enable http caching for one day of static assets
) do |sidekiq_web|
  # you can add your own middleware or additional settings here
end
```

The old way still works but will be removed in 8.0. Note also the new tag helpers `script_tag` and `style_tag` which handle the "nonce-sense" (ha ha) for you.