### PR TITLE
Make scheduled jobs be correctly scheduled in case the Redis client raises an error that is then retried successfully

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -248,10 +248,10 @@ module Sidekiq
     def atomic_push(conn, payloads)
       if payloads.first.key?("at")
         conn.zadd("schedule", payloads.flat_map { |hash|
-          at = hash.delete("at").to_s
+          at = hash["at"].to_s
           # ActiveJob sets this but the job has not been enqueued yet
           hash.delete("enqueued_at")
-          [at, Sidekiq.dump_json(hash)]
+          [at, Sidekiq.dump_json(hash.except("at"))]
         })
       else
         queue = payloads.first["queue"]


### PR DESCRIPTION
It appears that when jobs are scheduled with the default client, in case the Redis client raises an error that is then subsequently retried, the jobs get pushed into the queue itself, not the sorted set. This happens because `atomic_push` deletes the `at` key from every payload, which triggers the other branch of the method on the next retry, which `lpush`es the payloads directly into the original queue.

Here's a short reproduction script that displays the problem, should be run in the current main branch:

```ruby
#!/usr/bin/env ruby

require "bundler/inline"

require "prettyprint"

gemfile do
  source "https://rubygems.org"

  gem "sidekiq", path: "."
end

AGGREGATOR = Hash.new do |hash, key|
  hash[key] = Hash.new do |inner_hash, inner_key|
    inner_hash[inner_key] = []
  end
end

AGGREGATOR[:raised_once] = false

module Sidekiq
  class RedisClientAdapter
    module CompatMethods
      def zadd(set, payloads)
        if AGGREGATOR[:raised_once] == false
          AGGREGATOR[:raised_once] = true
          raise RedisClient::Error, "READONLY"
        else
          AGGREGATOR[:zadd][set].push(*payloads)
        end
      end

      def sadd(set, elements)
        AGGREGATOR[:sadd][set].push(*elements)
      end

      def lpush(list, elements)
        AGGREGATOR[:lpush][list].push(*elements)
      end
    end
  end
end

job_class = Class.new do
  include Sidekiq::Worker
end

client = Sidekiq::Client.new
client.push_bulk("class" => job_class, "args" => (1..10).map { [_1] }, "at" => 10)

pp AGGREGATOR

# This will NOT raise in current main
raise if AGGREGATOR[:zadd]["schedule"].size != 0
raise if AGGREGATOR[:sadd]["queues"] != ["default"]
raise if AGGREGATOR[:lpush]["queue:default"].size != 10
```

However, the proposed fix for this requires an additional implicit allocation of the payload due to `Hash#except`. Let me know if this can be circumvented somehow.