### PR TITLE
Retain CurrentAttributes after inline execution

### DIFF
--- a/test/current_attributes_test.rb
+++ b/test/current_attributes_test.rb
@@ -14,6 +14,13 @@ module Myapp
   end
 end
 
+class CurrentAttributesJob
+  include Sidekiq::Job
+
+  def perform
+  end
+end
+
 describe "Current attributes" do
   before do
     @config = reset!
@@ -91,6 +98,15 @@ describe "Current attributes" do
           assert_equal 17, job_hash["cattr_1"][:other_id]
         end
       end
+    end
+  end
+
+  it "persists after perform_inline" do
+    Sidekiq::CurrentAttributes.persist("Myapp::Current", @config)
+    with_context("Myapp::Current", :user_id, 16) do
+      assert_equal 16, Myapp::Current.user_id
+      CurrentAttributesJob.perform_inline
+      assert_equal 16, Myapp::Current.user_id
     end
   end
 


### PR DESCRIPTION
Ensure CurrentAttributes are restored to their original values, rather than cleared.

Fixes #6306