### PR TITLE
Do not fail on invalid locale in session hash

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -166,7 +166,7 @@ module Sidekiq
     def locale
       # session[:locale] is set via the locale selector from the footer
       # defined?(session) && session are used to avoid exceptions when running tests
-      return session[:locale].to_s if defined?(session) && session&.[](:locale)
+      return session[:locale].to_s if defined?(session) && session&.[](:locale) && available_locales.include?(session[:locale].to_s)
 
       @locale ||= begin
         matched_locale = user_preferred_languages.map { |preferred|

--- a/test/web_helpers_test.rb
+++ b/test/web_helpers_test.rb
@@ -108,6 +108,18 @@ describe "Web helpers" do
     assert_equal "es", obj.locale
   end
 
+  it "tests user selected locale with invalid locale" do
+    obj = Helpers.new("HTTP_ACCEPT_LANGUAGE" => "*")
+
+    obj.instance_eval do
+      def session
+        {locale: "xx"}
+      end
+    end
+
+    assert_equal "en", obj.locale
+  end
+
   it "tests available locales" do
     obj = Helpers.new
     expected = %w[


### PR DESCRIPTION
Prior to this commit, Sidekiq would treat the `locale` key in the session as safe: If it's set, it's surely a supported locale. However, in complex applications, the `locale` key in the session might be set by another app to some value that is not what Sidekiq expects.

In this case, Sidekiq fails with a 404 error and no good explanation.

What this commit does is make sure that the value in `session[:locale]` is actually a supported, available locale for Sidekiq. In case this is an unwanted locale, a user can still use the locale selector to change it back, but the Sidekiq admin doesn't suddenly become unreachable.

Another route this issue could be solved is by namespacing the `locale` key in the session to something like `sidekiq_locale`, in order to be safer from other parts of the app setting this value to something odd. I'm opting for this approach though because I believe it to be a less invasive change.