### PR TITLE
Add `logger` as an explicit dependency

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ HEAD (7.3.0)
 - Retain CurrentAttributeѕ after inline execution [#6307]
 - Raise default Redis {read,write,connect} timeouts from 1 to 3 seconds
   to minimize ReadTimeoutErrors [#6162]
+- Add `logger` as a dependency since it will become bundled in Ruby 3.5 [#6320]
 
 7.2.4
 ----------

--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "connection_pool", ">= 2.3.0"
   gem.add_dependency "rack", ">= 2.2.4"
   gem.add_dependency "concurrent-ruby", "< 2"
+  gem.add_dependency "logger"
 end


### PR DESCRIPTION
Sidekiq uses this and it's getting the same treatment like `base64`, `mutex_m`, etc. Starting in Ruby 3.4 a warning will be emitted, and Ruby 3.5 will error

Closes #6319