### PR TITLE
Don't allow to pass nil to Rack::Utils.escape_html

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -356,7 +356,7 @@ module Sidekiq
     end
 
     def h(text)
-      ::Rack::Utils.escape_html(text)
+      ::Rack::Utils.escape_html(text.to_s)
     rescue ArgumentError => e
       raise unless e.message.eql?("invalid byte sequence in UTF-8")
       text.encode!("UTF-16", "UTF-8", invalid: :replace, replace: "").encode!("UTF-8", "UTF-16")


### PR DESCRIPTION
Rack 3.1 [changed](https://github.com/rack/rack/pull/2099) how Rack::Utils.escape_html works and now it fails on nil. 

Fixes https://github.com/sidekiq/sidekiq/issues/6325