### PR TITLE
Eagerly load API to allow usage when route drawing is deferred

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -27,6 +27,7 @@ begin
 rescue LoadError
 end
 
+require "sidekiq/api"
 require "sidekiq/config"
 require "sidekiq/logger"
 require "sidekiq/client"

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "sidekiq"
-
 require "zlib"
 require "set"
 

--- a/lib/sidekiq/metrics/query.rb
+++ b/lib/sidekiq/metrics/query.rb
@@ -1,4 +1,3 @@
-require "sidekiq"
 require "date"
 require "set"
 

--- a/test/actors_test.rb
+++ b/test/actors_test.rb
@@ -5,7 +5,6 @@ require "sidekiq/cli"
 require "sidekiq/fetch"
 require "sidekiq/scheduled"
 require "sidekiq/processor"
-require "sidekiq/api"
 
 class JoeJob
   include Sidekiq::Job

--- a/test/sharding_test.rb
+++ b/test/sharding_test.rb
@@ -2,7 +2,6 @@
 
 require_relative "helper"
 require "sidekiq"
-require "sidekiq/api"
 
 class ShardJob
   include Sidekiq::Job


### PR DESCRIPTION
Now that route drawing will be deferred on environments where eager load is set to false on rails 8, the Sidekiq API wasn't available on rails console in these environments.

Closes #6332