### PR TITLE
Ignore non-existent CurrentAttributes attributes when restoring

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -30,6 +30,7 @@ See the [Iteration](//github.com/sidekiq/sidekiq/wiki/Iteration) wiki page and t
   start/finish job logging. [#6200]
 - Allow `Sidekiq::Limiter.redis` to use Redis Cluster [#6288]
 - Retain CurrentAttributeѕ after inline execution [#6307]
+- Ignore non-existent CurrentAttributes attributes when restoring [#6341]
 - Raise default Redis {read,write,connect} timeouts from 1 to 3 seconds
   to minimize ReadTimeoutErrors [#6162]
 - Add `logger` as a dependency since it will become bundled in Ruby 3.5 [#6320]

--- a/test/current_attributes_test.rb
+++ b/test/current_attributes_test.rb
@@ -110,6 +110,18 @@ describe "Current attributes" do
     end
   end
 
+  it "ignores non-existent attributes" do
+    cm = Sidekiq::CurrentAttributes::Load.new({
+      "cattr" => "Myapp::Current"
+    })
+
+    job = {"cattr" => {"user_id" => 123, "non_existent" => 456}}
+    assert_nil Myapp::Current.user_id
+    cm.call(nil, job, nil) do
+      assert_equal 123, Myapp::Current.user_id
+    end
+  end
+
   private
 
   def with_context(strklass, attr, value)


### PR DESCRIPTION
Fixes #6341.

I can't think of an easy way of safely removing the CurrentAttributes value without breaking the existing job 🤔. And it forces people to always remember about this gotcha.

I think we can just ignore non-existing attributes when restoring.