### PR TITLE
fix bottom nav bar overlap on large screen devices

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -634,8 +634,12 @@ div.interval-slider input {
 .container {
   padding: 0;
 }
+.navbar-fixed-bottom {
+  position: relative;
+  top: auto;
+}
 @media (max-width: 767px) {
-  .navbar-fixed-top, .navbar-fixed-bottom {
+  .navbar-fixed-top {
     position: relative;
     top: auto;
   }


### PR DESCRIPTION
Closes: https://github.com/sidekiq/sidekiq/issues/6327#issue-2346777247

Resolves the bottom nav bar overlap by removing the media query and keeping the nav bar fixed to the bottom of the page.