### PR TITLE
Use public rails api for broadcasting logs

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -62,6 +62,10 @@ module Sidekiq
         unless ::Rails.logger == config.logger || ::ActiveSupport::Logger.logger_outputs_to?(::Rails.logger, $stdout)
           if ::Rails.logger.respond_to?(:broadcast_to)
             ::Rails.logger.broadcast_to(config.logger)
+          elsif defined?(::ActiveSupport::BroadcastLogger)
+            # use public rails api for broadcasting logs (2023)
+            # - see commit https://github.com/rails/rails/commit/1fbd812c47f7ba840390942e56d9b2ebbc260901
+            ::Rails.logger = ::ActiveSupport::BroadcastLogger.new(::Rails.logger, config.logger)
           else
             ::Rails.logger.extend(::ActiveSupport::Logger.broadcast(config.logger))
           end


### PR DESCRIPTION
Hi there, I updated my gems to sidekiq 7.3.0 and activesupport 7.1.3.4 and noticed that sidekiq was failing to boot in my environment. It seems that the rails activesupport broadcast logger changed. I am submitting the fix I used to resolve my crash in case it is of any help to others.

Here is the relevant rails activesupport commit for more information: https://github.com/rails/rails/commit/1fbd812c47f7ba840390942e56d9b2ebbc260901

Error Stacktrace:
```
undefined method `broadcast' for class ActiveSupport::Logger
/usr/local/bundle/gems/sidekiq-7.3.0/lib/sidekiq/rails.rb:66:in `block (2 levels) in <class:Rails>'
/usr/local/bundle/gems/sidekiq-7.3.0/lib/sidekiq.rb:99:in `configure_server'
/usr/local/bundle/gems/sidekiq-7.3.0/lib/sidekiq/rails.rb:57:in `block in <class:Rails>'
/usr/local/bundle/gems/activesupport-7.1.3.4/lib/active_support/lazy_load_hooks.rb:94:in `block in execute_hook'
/usr/local/bundle/gems/activesupport-7.1.3.4/lib/active_support/lazy_load_hooks.rb:87:in `with_execution_control'
/usr/local/bundle/gems/activesupport-7.1.3.4/lib/active_support/lazy_load_hooks.rb:92:in `execute_hook'
/usr/local/bundle/gems/activesupport-7.1.3.4/lib/active_support/lazy_load_hooks.rb:78:in `block in run_load_hooks'
/usr/local/bundle/gems/activesupport-7.1.3.4/lib/active_support/lazy_load_hooks.rb:77:in `each'
/usr/local/bundle/gems/activesupport-7.1.3.4/lib/active_support/lazy_load_hooks.rb:77:in `run_load_hooks'
/usr/local/bundle/gems/railties-7.1.3.4/lib/rails/application/finisher.rb:93:in `block in <module:Finisher>'
```

Feel free to decline this PR if another approach is approriate. Thanks!
