### PR TITLE
Require sidekiq/component in Sidekiq::JobLogger

### DIFF
--- a/lib/sidekiq/job_logger.rb
+++ b/lib/sidekiq/job_logger.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "sidekiq/component"
+
 module Sidekiq
   class JobLogger
     include Sidekiq::Component


### PR DESCRIPTION
After upgrading to version `7.3.0` from `7.2.4` on a Rails application with `eager_loader` enabled in which `sidekiq` is a transitive/indirect dependency that sometimes is not used, we are getting an `uninitialized constant Sidekiq::Component (NameError)` in `Sidekiq::JobLogger`.

In this scenario, `sidekiq` is not required or a direct dependency when defining a local "structured logger" in an internal gem, so that error is raised.

Ensuring `sidekiq/component` is required in `Sidekiq::JobLogger` solves the problem, but I understand this scenario is not ideal/expected (defining a logger in an application that Sidekiq is not expected to run but is defined as an indirect dependency).


Stack trace:

```
/app # bundle exec rails console
/bundle/ruby/3.3.0/gems/sidekiq-7.3.0/lib/sidekiq/job_logger.rb:5:in `<class:JobLogger>': uninitialized constant Sidekiq::Component (NameError)

    include Sidekiq::Component
                   ^^^^^^^^^^^
Did you mean?  Complex
	from /bundle/ruby/3.3.0/gems/sidekiq-7.3.0/lib/sidekiq/job_logger.rb:4:in `<module:Sidekiq>'
	from /bundle/ruby/3.3.0/gems/sidekiq-7.3.0/lib/sidekiq/job_logger.rb:3:in `<main>'
	from <internal:/usr/local/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/usr/local/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /bundle/ruby/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/kernel.rb:34:in `require'
	from /bundle/ruby/3.3.0/gems/sequra-observability-0.18.0/lib/sequra/observability/sidekiq/logger/structured_logger.rb:2:in `<main>'
	from <internal:/usr/local/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/usr/local/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
...
```