### PR TITLE
Require `sidekiq/component` in `job_logger`

### DIFF
--- a/lib/sidekiq/job_logger.rb
+++ b/lib/sidekiq/job_logger.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "sidekiq/component"
+
 module Sidekiq
   class JobLogger
     include Sidekiq::Component


### PR DESCRIPTION
Upgrading an application that uses [`sidekiq-logstash`](https://github.com/iMacTia/sidekiq-logstash) to 7.3 causes the following error:

```
NameError: uninitialized constant Sidekiq::Component (NameError)

    include Sidekiq::Component
                   ^^^^^^^^^^^
Did you mean?  CompositeIO
/usr/local/bundle/gems/sidekiq-7.3.0/lib/sidekiq/job_logger.rb:5:in `<class:JobLogger>'
/usr/local/bundle/gems/sidekiq-7.3.0/lib/sidekiq/job_logger.rb:4:in `<module:Sidekiq>'
/usr/local/bundle/gems/sidekiq-7.3.0/lib/sidekiq/job_logger.rb:3:in `<main>'
/usr/local/bundle/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/usr/local/bundle/gems/sidekiq-logstash-3.0.0/lib/sidekiq/logstash_job_logger.rb:3:in `<main>'
/usr/local/bundle/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/usr/local/bundle/gems/sidekiq-logstash-3.0.0/lib/sidekiq/logstash.rb:7:in `<main>'
...
```

This seems to be caused by [`sidekiq-logstash` only requiring the `sidekiq/job_logger` module](https://github.com/iMacTia/sidekiq-logstash/blob/bfa22027f9dd7b9ed9ba6358187850ad347288c7/lib/sidekiq/logstash_job_logger.rb), rather than the entire `sidekiq` project. The `job_logger` module uses `Sidekiq::Component` but doesn't explicitly require it.

I'm not sure what the correct style for this project is; some modules seem to explicitly require their dependencies, while others don't, or seem to require a subset of dependencies. I'm also not sure if it's "correct" for `sidekiq-logstash` to directly require the `job_logger` module. Open to suggestion if this isn't the right way to go about resoling this incompatibility.