### PR TITLE
Add note about required dogstatsd-ruby gem version

### DIFF
--- a/docs/Pro-7.0-Upgrade.md
+++ b/docs/Pro-7.0-Upgrade.md
@@ -29,6 +29,7 @@ end
 - Redis 6.2+ is now required
 - Ruby 2.7+ is now required
 - Rails 6.0+ is now supported
+- If using `dogstatsd-ruby`, v5.0+ is now required
 
 Support is only guaranteed for the current and previous major versions. With the release of Sidekiq Pro 7, Sidekiq Pro 4.x is no longer supported.
 


### PR DESCRIPTION
We ran into an error when trying to upgrade Sidekiq gems to v7 without first upgrading `dogstatsd-ruby` from v4 to v5.

```rb
NoMethodError
undefined method `host' for #<Datadog::Statsd:0x00007f29c1c5bc40 ...
...
sidekiq-pro (7.2.1) lib/sidekiq/pro/metrics.rb in block in location at line 81
```

Adding a note for others that may run into the same issue.