### PR TITLE
Fix `script_tag` and `style_tag` on Ruby 2.7

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -36,7 +36,7 @@ module Sidekiq
     # NB: keys and values are not escaped; do not allow user input
     # in the attributes
     private def html_tag(tagname, attrs)
-      s = "<#{tagname}"
+      s = +"<#{tagname}"
       attrs.each_pair do |k, v|
         next unless v
         s << " #{k}=\"#{v}\""

--- a/test/web_helpers_test.rb
+++ b/test/web_helpers_test.rb
@@ -44,6 +44,16 @@ describe "Web helpers" do
     Sidekiq.redis { |c| c.flushdb }
   end
 
+  it "tests script_tag" do
+    obj = Helpers.new
+    assert_equal '<script type="text/javascript" src="/sidekiq.js"></script>', obj.script_tag("sidekiq.js")
+  end
+
+  it "tests style_tag" do
+    obj = Helpers.new
+    assert_equal '<link type="text/css" media="screen" rel="stylesheet" href="/sidekiq.css" />', obj.style_tag("sidekiq.css")
+  end
+
   it "tests locale determination" do
     obj = Helpers.new
     assert_equal "en", obj.locale


### PR DESCRIPTION
On Ruby 2.7 (and earlier), when a frozen magic comment is encountered, interpolated strings are frozen as well.

Closes #6371