### PR TITLE
Don't use `Hash#except` which only got added in Ruby 3.0

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ HEAD
 
 - Add frozen string literal to a number of .rb files.
 - Fix frozen string error with style_tag and script_tag [#6371]
+- Fix an error on Ruby 2.7 because of usage of `Hash#except` [#6376]
 
 7.3.0
 ----------

--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -251,7 +251,10 @@ module Sidekiq
           at = hash["at"].to_s
           # ActiveJob sets this but the job has not been enqueued yet
           hash.delete("enqueued_at")
-          [at, Sidekiq.dump_json(hash.except("at"))]
+          # TODO: Use hash.except("at") when support for Ruby 2.7 is dropped
+          hash = hash.dup
+          hash.delete("at")
+          [at, Sidekiq.dump_json(hash)]
         })
       else
         queue = payloads.first["queue"]


### PR DESCRIPTION
Closes #6376

@mhenrixon is correct in his assesment that this method is loaded through activesupport. I'm not sure if there is a good solution so that this doesn't happen again in the future. There would need to be some isolation so that rails specific tests don't polute.

For example, these are the extra methods available when running tests, through activesupport, on a Hash with Ruby 2.7:
```rb
m = {}.methods
require "active_support"
{}.methods - m
# => [:slice!, :except!, :deep_merge?, :except, :extract!, :deep_merge, :deep_merge!]
```