### PR TITLE
Fix yaml syntax problem in tr.yml

### DIFF
--- a/web/locales/tr.yml
+++ b/web/locales/tr.yml
@@ -4,7 +4,7 @@ tr:
   AddToQueue: Kuyruğa ekle
   AreYouSure: Emin misiniz?
   AreYouSureDeleteJob: Bu işi silmek istediğinizden emin misiniz?
-  AreYouSureDeleteQueue: %{queue} kuyruğunu silmek istediğinizden emin misiniz?
+  AreYouSureDeleteQueue: "%{queue} kuyruğunu silmek istediğinizden emin misiniz?"
   Arguments: Argümanlar
   BackToApp: Uygulamaya geri dön
   Busy: Meşgul


### PR DESCRIPTION
Ruby version: 3.3.0
Rails version: 7.1.3.4
Sidekiq / Pro / Enterprise version(s): 7.3.0

The error caused by ignoring the need to use quotation marks when the interpolation variable in the translation for the **AreYouSureDeleteQueue** keyword is at the beginning of the sentence has been fixed.

![image](https://github.com/user-attachments/assets/d1af41df-2b93-4234-a32a-122b50aa1ded)
