### PR TITLE
Require component from job logger

### DIFF
--- a/lib/sidekiq/job_logger.rb
+++ b/lib/sidekiq/job_logger.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "sidekiq/component"
+
 module Sidekiq
   class JobLogger
     include Sidekiq::Component


### PR DESCRIPTION
Since this [change](https://github.com/sidekiq/sidekiq/commit/6677b453982cab276892e7dad65cb320582b7de3), (and [sidekiq v7.3.0](https://github.com/sidekiq/sidekiq/releases/tag/v7.3.0)) the JobLogger depends on `Sidekiq::Component`. 

For apps that only `require "sidekiq/job_logger"`, this can lead to a `NameError`:

```
/home/nuno/.bundle/myapp/ruby-3.3.1/gems/sidekiq-7.3.0/lib/sidekiq/job_logger.rb:5:in `<class:JobLogger>': uninitialized constant Sidekiq::Component (NameError)

    include Sidekiq::Component
                   ^^^^^^^^^^^
        from /home/nuno/.bundle/myapp/ruby-3.3.1/gems/sidekiq-7.3.0/lib/sidekiq/job_logger.rb:4:in `<module:Sidekiq>'
        from /home/nuno/.bundle/myapp/ruby-3.3.1/gems/sidekiq-7.3.0/lib/sidekiq/job_logger.rb:3:in `<top (required)>'
        from /opt/rubies/ruby-3.3.1/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
```

This PR adds `require "sidekiq/component"` to avoid this error from happening.