### PR TITLE
Fix the comparison of version from strings to numerics.

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -11,7 +11,7 @@ module Sidekiq
       end
 
       def call
-        params = (::Rails::VERSION::STRING >= "7.1") ? {source: "job.sidekiq"} : {}
+        params = (Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new('7.1')) ? {source: "job.sidekiq"} : {}
         @app.reloader.wrap(**params) do
           yield
         end


### PR DESCRIPTION
This is a lexicographical comparison: '7.10' < '7.2' which gives `true`, which is incorrect. This is solved using `Gem::Version.new`.