### PR TITLE
Fix startup error when redis sentinel is provided as an url

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -66,7 +66,14 @@ module Sidekiq
         scrubbed_options[:password] = redacted if scrubbed_options[:password]
         scrubbed_options[:sentinel_password] = redacted if scrubbed_options[:sentinel_password]
         scrubbed_options[:sentinels]&.each do |sentinel|
-          sentinel[:password] = redacted if sentinel[:password]
+          if sentinel.is_a?(String)
+            if (uri = URI(sentinel)) && uri.password
+              uri.password = redacted
+              sentinel.replace(uri.to_s)
+            end
+          else
+            sentinel[:password] = redacted if sentinel[:password]
+          end
         end
         scrubbed_options
       end

--- a/test/redis_connection_test.rb
+++ b/test/redis_connection_test.rb
@@ -172,6 +172,21 @@ describe Sidekiq::RedisConnection do
         assert_includes(output, ':password=>"REDACTED"')
       end
 
+      it "supports sentinel urls" do
+        options = {
+          url: "rediss://user:secret@mymaster",
+          sentinels: ["rediss://sentinel-user:secret@sentinel-host:26379"]
+        }
+
+        output = capture_logging(@config) do |logger|
+          Sidekiq::RedisConnection.create(options.merge(logger: logger))
+        end
+
+        refute_includes(options.inspect, "REDACTED")
+        refute_includes(output, "secret")
+        assert_includes(output, "sentinel-user:REDACTED@sentinel-host:26379")
+      end
+
       it "prunes SSL parameters from the logging" do
         output = capture_logging(@config) do |logger|
           options = {


### PR DESCRIPTION
redis-client does support providing sentinels via urls, but when trying to use such config in sidekiq and having logging enabled, it errors
> TypeError: no implicit conversion of Symbol into Integer
> lib/sidekiq/redis_connection.rb:74:in `[]'

Funny point is that it does not error, when sidekiq's logger level is filtering `info` thus it did not show up in my tests at first, only in production 🙈 

This PR fixes `RedisConnection::scrub` so that it does not choke on strings in sentinels.