### PR TITLE
Reduce max-width for redis-url elements

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -634,12 +634,8 @@ div.interval-slider input {
 .container {
   padding: 0;
 }
-.navbar-fixed-bottom {
-  position: relative;
-  top: auto;
-}
 @media (max-width: 767px) {
-  .navbar-fixed-top {
+  .navbar-fixed-top, .navbar-fixed-bottom {
     position: relative;
     top: auto;
   }
@@ -652,18 +648,18 @@ div.interval-slider input {
 
 @media (min-width: 768px) {
   .redis-url {
-    max-width: 250px;
+    max-width: 160px;
   }
 }
 
 @media (min-width: 992px) {
   .redis-url {
-    max-width: 490px;
+    max-width: 380px;
   }
 }
 @media (min-width: 1200px) {
   .redis-url {
-    max-width: 600px;
+    max-width: 580px;
   }
 }
 


### PR DESCRIPTION
Closes: https://github.com/sidekiq/sidekiq/issues/6409

Reverting https://github.com/sidekiq/sidekiq/pull/6350 while providing a new fix for [the original issue](https://github.com/sidekiq/sidekiq/issues/6327) of the nav bar overlapping content in the body of the page.

Reducing the max-width of the `redis-url` will prevent the wrapping of elements in the footer and the overlap on the body contents.

Before (buttons are not visible):
<img width="1218" alt="Screenshot 2024-08-30 at 1 32 16 PM" src="https://github.com/user-attachments/assets/f4578f2e-ffc8-4141-9462-ba747ac6120a">

After:
<img width="1208" alt="Screenshot 2024-08-30 at 1 32 48 PM" src="https://github.com/user-attachments/assets/7b76d9a1-58f0-46cc-bd3e-0d0ae084d2b2">
