### PR TITLE
Replace usage of OpenStruct with Struct

### DIFF
--- a/test/sidekiqmon_test.rb
+++ b/test/sidekiqmon_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "helper"
-require "ostruct"
 require "sidekiq/monitor"
 
 def capture_stdout
@@ -42,7 +41,7 @@ describe Sidekiq::Monitor do
       end
 
       it "displays the correct output" do
-        mock_stats = OpenStruct.new(
+        stats_attributes = {
           processed: 420710,
           failed: 12,
           workers_size: 34,
@@ -50,7 +49,8 @@ describe Sidekiq::Monitor do
           retry_size: 78,
           scheduled_size: 90,
           dead_size: 666
-        )
+        }
+        mock_stats = Struct.new(*stats_attributes.keys).new(*stats_attributes.values)
         Sidekiq::Stats.stub(:new, mock_stats) do
           assert_includes output, "Processed: 420,710"
           assert_includes output, "Failed: 12"
@@ -92,9 +92,10 @@ describe Sidekiq::Monitor do
       end
 
       it "displays the correct output" do
+        queue_struct = Struct.new(:name, :size, :latency)
         mock_queues = [
-          OpenStruct.new(name: "foobar", size: 12, latency: 12.3456),
-          OpenStruct.new(name: "a_long_queue_name", size: 234, latency: 567.89999)
+          queue_struct.new("foobar", 12, 12.3456),
+          queue_struct.new("a_long_queue_name", 234, 567.89999)
         ]
         Sidekiq::Queue.stub(:all, mock_queues) do
           assert_includes output, "NAME                 SIZE  LATENCY"


### PR DESCRIPTION
Ruby 3.3.5 warns when requiring `ostruct` from the standard library (as opposed to requiring it as a gem). Such a warning can be seen in the Ruby 3.3 build in CI [here][1], since `test/sidekiqmon_test.rb` has `require "ostruct"`, but `ostruct` is not specified in the Gemfile or gemspec as a gem dependency.

[1]: https://github.com/sidekiq/sidekiq/actions/runs/10710835954/job/29698382673#step:6:7

This is the warning:

> /home/runner/work/sidekiq/sidekiq/test/sidekiqmon_test.rb:4: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
>
> You can add ostruct to your Gemfile or gemspec to silence this warning.

In order to get rid of that warning when running tests, this change removes all usage of `OpenStruct` from Sidekiq. There were only a few such usages, all in `test/sidekiqmon_test.rb`. This change replaces those `OpenStruct` usages with `Struct`, and removes the `require "ostruct"` from the top of that file.

#6420 is an alternative possible solution. If that PR is merged, then this PR should be closed without merging.

# Screenshots

_[Running tests on Ruby **3.3.5**]_

## Before

![image](https://github.com/user-attachments/assets/5b7fd026-0dca-49f6-9c57-15f80f4708da)

## After

![image](https://github.com/user-attachments/assets/5a6685d4-71d4-45fe-b806-6b4e7388511f)