### PR TITLE
Add 'ostruct' (for OpenStruct) to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "csv"
 
 group :test do
   gem "maxitest"
+  gem "ostruct"
   gem "simplecov"
 end
 


### PR DESCRIPTION
Ruby 3.3.5 warns when requiring `ostruct` from the standard library (as opposed to requiring it as a gem). Such a warning can be seen in the Ruby 3.3 build in CI [here][1], since `test/sidekiqmon_test.rb` has `require "ostruct"`, but `ostruct` is not specified in the Gemfile or gemspec as a gem dependency.

[1]: https://github.com/sidekiq/sidekiq/actions/runs/10710835954/job/29698382673#step:6:7

This is the warning:

> /home/runner/work/sidekiq/sidekiq/test/sidekiqmon_test.rb:4: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
>
> You can add ostruct to your Gemfile or gemspec to silence this warning.

In order to get rid of that warning when running tests, this change adds `ostruct` to the `:test` group of the Gemfile. This change means that `require "ostruct"` will now source `OpenStruct` from the [`ostruct` standalone Ruby gem][2], rather than from the Ruby standard library.

[2]: https://github.com/ruby/ostruct

#6419 is an alternative possible solution. If that PR is merged, then this PR should be closed without merging. Although the approach taken in this PR is a little simpler than that of #6419 (which is good), the approach taken in this PR adds another dependency (albeit a test-only dependency), which might be undesirable.

# Screenshots

_[Running tests on Ruby **3.3.5**]_

## Before

![image](https://github.com/user-attachments/assets/5b7fd026-0dca-49f6-9c57-15f80f4708da)

## After

![image](https://github.com/user-attachments/assets/7a0805a2-c4ce-483f-a385-2e623bcb58c2)