### PR TITLE
Renamed inst to instance

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -108,12 +108,12 @@ module Sidekiq
   # within an arbitrary Ruby process. Notably it reduces concurrency by
   # default so there is less contention for CPU time with other threads.
   #
-  #   inst = Sidekiq.configure_embed do |config|
+  #   instance = Sidekiq.configure_embed do |config|
   #     config.queues = %w[critical default low]
   #   end
-  #   inst.run
+  #   instance.run
   #   sleep 10
-  #   inst.stop
+  #   instance.stop
   #
   # NB: it is really easy to overload a Ruby process with threads due to the GIL.
   # I do not recommend setting concurrency higher than 2-3.

--- a/lib/sidekiq/capsule.rb
+++ b/lib/sidekiq/capsule.rb
@@ -40,9 +40,9 @@ module Sidekiq
 
     def fetcher
       @fetcher ||= begin
-        inst = (config[:fetch_class] || Sidekiq::BasicFetch).new(self)
-        inst.setup(config[:fetch_setup]) if inst.respond_to?(:setup)
-        inst
+        instance = (config[:fetch_class] || Sidekiq::BasicFetch).new(self)
+        instance.setup(config[:fetch_setup]) if instance.respond_to?(:setup)
+        instance
       end
     end
 

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -138,11 +138,11 @@ module Sidekiq
               # Effectively this block denotes a "unit of work" to Rails.
               @reloader.call do
                 klass = Object.const_get(job_hash["class"])
-                inst = klass.new
-                inst.jid = job_hash["jid"]
-                inst._context = self
-                @retrier.local(inst, jobstr, queue) do
-                  yield inst
+                instance = klass.new
+                instance.jid = job_hash["jid"]
+                instance._context = self
+                @retrier.local(instance, jobstr, queue) do
+                  yield instance
                 end
               end
             end
@@ -180,9 +180,9 @@ module Sidekiq
       ack = false
       Thread.handle_interrupt(IGNORE_SHUTDOWN_INTERRUPTS) do
         Thread.handle_interrupt(ALLOW_SHUTDOWN_INTERRUPTS) do
-          dispatch(job_hash, queue, jobstr) do |inst|
-            config.server_middleware.invoke(inst, job_hash, queue) do
-              execute_job(inst, job_hash["args"])
+          dispatch(job_hash, queue, jobstr) do |instance|
+            config.server_middleware.invoke(instance, job_hash, queue) do
+              execute_job(instance, job_hash["args"])
             end
           end
           ack = true
@@ -216,8 +216,8 @@ module Sidekiq
       end
     end
 
-    def execute_job(inst, cloned_args)
-      inst.perform(*cloned_args)
+    def execute_job(instance, cloned_args)
+      instance.perform(*cloned_args)
     end
 
     # Ruby doesn't provide atomic counters out of the box so we'll

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -283,11 +283,11 @@ module Sidekiq
       end
 
       def process_job(job)
-        inst = new
-        inst.jid = job["jid"]
-        inst.bid = job["bid"] if inst.respond_to?(:bid=)
-        Sidekiq::Testing.server_middleware.invoke(inst, job, job["queue"]) do
-          execute_job(inst, job["args"])
+        instance = new
+        instance.jid = job["jid"]
+        instance.bid = job["bid"] if instance.respond_to?(:bid=)
+        Sidekiq::Testing.server_middleware.invoke(instance, job, job["queue"]) do
+          execute_job(instance, job["args"])
         end
       end
 


### PR DESCRIPTION
Changed the variable name "inst" to "instance" for readability.