### PR TITLE
Show template filename in ERB error backtraces

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -213,7 +213,7 @@ module Sidekiq
   Sidekiq::WebApplication.helpers WebHelpers
   Sidekiq::WebApplication.helpers Sidekiq::Paginator
 
-  Sidekiq::WebAction.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+  Sidekiq::WebAction.class_eval <<-RUBY, Web::LAYOUT, -1 # standard:disable Style/EvalWithLocation
     def _render
       #{ERB.new(File.read(Web::LAYOUT)).src}
     end

--- a/lib/sidekiq/web/action.rb
+++ b/lib/sidekiq/web/action.rb
@@ -48,8 +48,12 @@ module Sidekiq
       if content.is_a? Symbol
         unless respond_to?(:"_erb_#{content}")
           views = options[:views] || Web.settings.views
-          src = ERB.new(File.read("#{views}/#{content}.erb")).src
-          WebAction.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          filename = "#{views}/#{content}.erb"
+          src = ERB.new(File.read(filename)).src
+
+          # Need to use lineno less by 1 because erb generates a
+          # comment before the source code.
+          WebAction.class_eval <<-RUBY, filename, -1 # standard:disable Style/EvalWithLocation
             def _erb_#{content}
               #{src}
             end


### PR DESCRIPTION
Fixes #6407.

Backtrace after:
```
/sidekiq/web/views/morgue.erb:7:in `_erb_morgue'
/sidekiq/lib/sidekiq/web/action.rb:99:in `_erb'
/sidekiq/lib/sidekiq/web/action.rb:68:in `erb'
/sidekiq/lib/sidekiq/web/application.rb:160:in `block in <class:WebApplication>'
/sidekiq/lib/sidekiq/web/application.rb:416:in `instance_exec'
/sidekiq/lib/sidekiq/web/application.rb:416:in `block in call'
/sidekiq/lib/sidekiq/web/application.rb:414:in `catch'
/sidekiq/lib/sidekiq/web/application.rb:414:in `call'
/sidekiq/lib/sidekiq/web/csrf_protection.rb:51:in `admit'
/sidekiq/lib/sidekiq/web/csrf_protection.rb:40:in `call'
```