### PR TITLE
Access arguments in iteration callbacks

### DIFF
--- a/lib/sidekiq/job/iterable.rb
+++ b/lib/sidekiq/job/iterable.rb
@@ -30,6 +30,11 @@ module Sidekiq
         @_cursor = nil
         @_start_time = nil
         @_runtime = 0
+        @_args = nil
+      end
+
+      def arguments
+        @_args
       end
 
       # A hook to override that will be called when the job starts iterating.
@@ -91,13 +96,14 @@ module Sidekiq
       end
 
       # @api private
-      def perform(*arguments)
+      def perform(*args)
+        @_args = args.dup.freeze
         fetch_previous_iteration_state
 
         @_executions += 1
         @_start_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
 
-        enumerator = build_enumerator(*arguments, cursor: @_cursor)
+        enumerator = build_enumerator(*args, cursor: @_cursor)
         unless enumerator
           logger.info("'#build_enumerator' returned nil, skipping the job.")
           return
@@ -112,7 +118,7 @@ module Sidekiq
         end
 
         completed = catch(:abort) do
-          iterate_with_enumerator(enumerator, arguments)
+          iterate_with_enumerator(enumerator, args)
         end
 
         on_stop

--- a/test/iterable/iterable_jobs.rb
+++ b/test/iterable/iterable_jobs.rb
@@ -157,6 +157,24 @@ class IterableJobWithArguments < SimpleIterableJob
   end
 end
 
+class DynamicCallbackJob < IterableJobWithArguments
+  CB = {}
+
+  %w[on_start on_complete on_stop on_resume].each do |cb|
+    name = cb.to_sym
+    CB[name] = []
+    define_method(name) do
+      CB[name].each { |cb| instance_exec(&cb) }
+    end
+  end
+  def self.reset
+    CB[:on_start] = []
+    CB[:on_stop] = []
+    CB[:on_resume] = []
+    CB[:on_complete] = []
+  end
+end
+
 class EmptyEnumeratorJob < SimpleIterableJob
   def build_enumerator(cursor:)
     array_enumerator([], cursor: cursor)

--- a/test/iterable/iterable_test.rb
+++ b/test/iterable/iterable_test.rb
@@ -252,6 +252,36 @@ describe Sidekiq::Job::Iterable do
     assert_equal (1..10).to_a, ActiveRecordRelationsJob.iterated_objects.flatten.uniq.map(&:id)
   end
 
+  describe "job arguments" do
+    it "are available to all callbacks" do
+      $args = {}
+      DynamicCallbackJob.reset
+      DynamicCallbackJob::CB[:on_stop] << -> { $args[:on_stop] = arguments }
+      DynamicCallbackJob::CB[:on_start] << -> { $args[:on_start] = arguments }
+      DynamicCallbackJob::CB[:on_complete] << -> { $args[:on_complete] = arguments }
+      DynamicCallbackJob::CB[:on_resume] << -> { $args[:on_resume] = arguments }
+
+      DynamicCallbackJob.perform_inline("mike", 123)
+      assert_equal($args, {on_start: ["mike", 123], on_stop: ["mike", 123], on_complete: ["mike", 123]})
+    end
+
+    it "are frozen" do
+      DynamicCallbackJob.reset
+      DynamicCallbackJob::CB[:on_start] << -> { arguments[1] = nil }
+      assert_raises FrozenError do
+        DynamicCallbackJob.perform_inline("mike", 123)
+      end
+    end
+
+    it "mangles keyword arguments, per JSON" do
+      $args = {}
+      DynamicCallbackJob.reset
+      DynamicCallbackJob::CB[:on_start] << -> { $args[:on_start] = arguments }
+      DynamicCallbackJob.perform_inline("first", mike: 456, bob: "string")
+      assert_equal($args, {on_start: ["first", {"mike" => 456, "bob" => "string"}]})
+    end
+  end
+
   private
 
   def iterate_exact_times(job, count, jid: nil)


### PR DESCRIPTION
Add  `arguments` accessor method to IterableJob so callbacks can easily access job arguments, see #6453