### PR TITLE
Fix typo in Sidekiq 7.0 migration doc

### DIFF
--- a/docs/7.0-API-Migration.md
+++ b/docs/7.0-API-Migration.md
@@ -87,7 +87,7 @@ Sidekiq.configure_server do |cfg|
 end
 
 # broken, can not read configuration directly anymore
-Sidekiq[:average_scheduled_poll_interval] NoMethodError: undefined method '[]' for Sidekiq:Module
+Sidekiq[:average_scheduled_poll_interval] # NoMethodError: undefined method '[]' for Sidekiq:Module
 
 # fixed
 Sidekiq.default_configuration[:average_scheduled_poll_interval] # 5


### PR DESCRIPTION
Noticed this small typo while reading through the doc.