### PR TITLE
Fix check whether SidekiqAdapter is defined or not

### DIFF
--- a/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -16,7 +16,7 @@ end
 module ActiveJob
   module QueueAdapters
     # Explicitly remove the implementation existing in older rails'.
-    remove_const(:SidekiqAdapter) if defined?(:SidekiqAdapter)
+    remove_const(:SidekiqAdapter) if defined?("::#{name}::SidekiqAdapter")
 
     # Sidekiq adapter for Active Job
     #


### PR DESCRIPTION
When Ruby parses the expression

```ruby
defined?(:ANY_SYMBOL_IMAGINABLE)
```

it recognizes the symbol `:ANY_SYMBOL_IMAGINABLE` and adds it to its list of known symbols. Therefore the expression

```ruby
defined?(:ANY_SYMBOL_IMAGINABLE)
```

will always be truthy.

If we use

```ruby
module ActiveJob
  module QueueAdapters
    remove_const(:SidekiqAdapter) if defined?(SidekiqAdapter)
```

This checks for the existence of `::ActiveJob::QueueAdapters::SidekiqAdapter`, but would also give a false positive if `::ActiveJob::SidekiqAdapter` or `::SidekiqAdapter` are defined.

What we really want is

```ruby
module ActiveJob
  module QueueAdapters
    remove_const(:SidekiqAdapter) if defined?("::#{name}::SidekiqAdapter")
```