### PR TITLE
Fix circular require for ActiveJob integration

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -3,12 +3,6 @@
 require "sidekiq/job"
 require "rails"
 
-begin
-  require "active_job"
-  require "active_job/queue_adapters/sidekiq_adapter"
-rescue LoadError
-end
-
 module Sidekiq
   class Rails < ::Rails::Engine
     class Reloader
@@ -45,6 +39,8 @@ module Sidekiq
     #   end
     initializer "sidekiq.active_job_integration" do
       ActiveSupport.on_load(:active_job) do
+        require "active_job/queue_adapters/sidekiq_adapter"
+
         include ::Sidekiq::Job::Options unless respond_to?(:sidekiq_options)
       end
     end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/53460 (cc @zzak)

We have a circular require error
https://github.com/rails/rails/blob/e6429269fd5a8a7d728557f4e7d7f82c0ad1478c/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb#L4
https://github.com/sidekiq/sidekiq/blob/bd3604909687bb0a0f4e71e087eb5a75e69fdf83/lib/sidekiq/rails.rb#L8