### PR TITLE
Allow footer nav to fill container

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -650,6 +650,11 @@ div.interval-slider input {
   .redis-url {
     max-width: 160px;
   }
+
+  .navbar-fixed-bottom .nav {
+    margin-left: -15px;
+    margin-right: -15px;
+  }
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
With Sidekiq Pro and Enterprise installed and a long redis URL, the footer nav overflows onto two rows at multiple breakpoints, including large screens. The double-height footer can make it hard to access the elements at the bottom of some pages, like the buttons at the bottom of the Retries page.

The wrapping is caused by the 15px margin added by `.nav-text`, which reduces the responsive container’s width by 30px. When the combined text items are long enough, the elements start to wrap.


Removing the extra margin on the edges allows the nav element to fill the container so the items fit on one row at all screen sizes.

**Before:**

![footer-before](https://github.com/user-attachments/assets/23077157-7076-49e4-b572-b7f6438b6291)

**After:** 

![footer-after](https://github.com/user-attachments/assets/21bc4b72-cc6e-4466-809a-dc7ed7a3190f)