### PR TITLE
Rewrite retry_all and kill_all APIs to use ZPOPMIN 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,10 @@
 HEAD
 ----------
 
+- Reimplement `retry_all` and `kill_all` API methods to use ZPOPMIN,
+  approximately 30-60% faster. [#6481]
+- Add preload testing binary at `examples/testing/sidekiq_boot` to verify your Rails app boots correctly with Sidekiq Enterprise's app preloading.
+- Fix circular require with ActiveJob adapter [#6477]
 - Fix potential race condition leading to incorrect serialized values for CurrentAttributes [#6475]
 
 7.3.4

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -790,7 +790,6 @@ module Sidekiq
     end
 
     alias_method :delete, :delete_by_jid
-
   end
 
   ##

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -668,9 +668,13 @@ module Sidekiq
       end
     end
 
-    def pop_each(&block)
-      size.times do
-        popmin(&block)
+    def pop_each
+      Sidekiq.redis do |c|
+        size.times do
+          data, score = c.zpopmin(name, 1)&.first
+          break unless data
+          yield data, score
+        end
       end
     end
 
@@ -787,13 +791,6 @@ module Sidekiq
 
     alias_method :delete, :delete_by_jid
 
-    def popmin
-      Sidekiq.redis { |c|
-        data, score = c.zpopmin(name, 1)&.first
-        break unless data
-        yield data, score
-      }
-    end
   end
 
   ##

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -724,7 +724,6 @@ describe "API" do
       assert_equal 1, ps.size
       assert_equal 1, ps.to_a.size
     end
-
   end
 
   describe "dead set" do

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -725,12 +725,6 @@ describe "API" do
       assert_equal 1, ps.to_a.size
     end
 
-    def add_retry(jid = "bob", at = Time.now.to_f)
-      payload = Sidekiq.dump_json("class" => "ApiJob", "args" => [1, "mike"], "queue" => "default", "jid" => jid, "retry_count" => 2, "failed_at" => Time.now.to_f, "error_backtrace" => ["line1", "line2"])
-      @cfg.redis do |conn|
-        conn.zadd("retry", at.to_s, payload)
-      end
-    end
   end
 
   describe "dead set" do
@@ -783,5 +777,43 @@ describe "API" do
       assert_equal 1, ds.size
       assert_equal 1, death_handler_call_count
     end
+
+    it "can retry and kill all safely" do
+      1000.times do
+        add_dead
+      end
+      500.times do
+        add_retry
+      end
+
+      q = Sidekiq::Queue.new
+      ds = Sidekiq::DeadSet.new
+      rs = Sidekiq::RetrySet.new
+      assert_equal 1000, ds.size
+      assert_equal 500, rs.size
+
+      ds.retry_all
+      assert_equal 0, ds.size
+      assert_equal 1000, q.size
+
+      rs.kill_all(notify_failure: false)
+      assert_equal 500, ds.size
+      assert_equal 0, rs.size
+    end
+  end
+end
+
+def add_retry(jid = "bob", at = Time.now.to_f)
+  payload = Sidekiq.dump_json("class" => "ApiJob", "args" => [1, "mike"], "queue" => "default", "jid" => jid, "retry_count" => 2, "failed_at" => Time.now.to_f, "error_backtrace" => ["line1", "line2"])
+  @cfg.redis do |conn|
+    conn.zadd("retry", at.to_s, payload)
+  end
+end
+
+def add_dead(jid = nil, at = Time.now.to_f)
+  jid ||= SecureRandom.hex(12)
+  payload = Sidekiq.dump_json("class" => "ApiJob", "args" => [1, "mike"], "queue" => "default", "jid" => jid)
+  @cfg.redis do |conn|
+    conn.zadd("dead", at.to_s, payload)
   end
 end


### PR DESCRIPTION
Instead of a paginated cursor, fixes #6481.