### PR TITLE
Correctly remove the buildin rails adapter

### DIFF
--- a/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -16,7 +16,7 @@ end
 module ActiveJob
   module QueueAdapters
     # Explicitly remove the implementation existing in older rails'.
-    remove_const(:SidekiqAdapter) if defined?("::#{name}::SidekiqAdapter")
+    remove_const(:SidekiqAdapter) if const_defined?(:SidekiqAdapter)
 
     # Sidekiq adapter for Active Job
     #


### PR DESCRIPTION
Followup #6474. cc @leoarnold 

`defined?` for a string literal is always truthy, same as for symbols. `defined?(ActiveJob::QueueAdapters::SidekiqAdapter)` would work as an alternative.

```rb
module ActiveJob
  module QueueAdapters
    # Adapter removed from rails
  end
end

module ActiveJob
  module QueueAdapters
    remove_const(:SidekiqAdapter) if defined?("::#{name}::SidekiqAdapter")
  end
end
```

`test.rb:10:in 'remove_const': constant ActiveJob::QueueAdapters::SidekiqAdapter not defined (NameError)`