### PR TITLE
Sidekiq Web: Apply filters on GET requests

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -76,7 +76,7 @@ module Sidekiq
       minutes = @periods.fetch(@period, @periods.values.first)
       @query_result = q.top_jobs(minutes: minutes, class_filter: class_filter)
 
-      erb :metrics
+      erb(:metrics)
     end
 
     get "/metrics/:name" do

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -157,9 +157,15 @@ module Sidekiq
     end
 
     get "/morgue" do
-      @count = (params["count"] || 25).to_i
-      (@current_page, @total_size, @dead) = page("dead", params["page"], @count, reverse: true)
-      @dead = @dead.map { |msg, score| Sidekiq::SortedEntry.new(nil, score, msg) }
+      x = params[:substr]
+
+      if x && x != ""
+        @dead = search(Sidekiq::DeadSet.new, x)
+      else
+        @count = (params["count"] || 25).to_i
+        (@current_page, @total_size, @dead) = page("dead", params["page"], @count, reverse: true)
+        @dead = @dead.map { |msg, score| Sidekiq::SortedEntry.new(nil, score, msg) }
+      end
 
       erb(:morgue)
     end
@@ -211,9 +217,15 @@ module Sidekiq
     end
 
     get "/retries" do
-      @count = (params["count"] || 25).to_i
-      (@current_page, @total_size, @retries) = page("retry", params["page"], @count)
-      @retries = @retries.map { |msg, score| Sidekiq::SortedEntry.new(nil, score, msg) }
+      x = params[:substr]
+
+      if x && x != ""
+        @retries = search(Sidekiq::RetrySet.new, x)
+      else
+        @count = (params["count"] || 25).to_i
+        (@current_page, @total_size, @retries) = page("retry", params["page"], @count)
+        @retries = @retries.map { |msg, score| Sidekiq::SortedEntry.new(nil, score, msg) }
+      end
 
       erb(:retries)
     end
@@ -266,9 +278,15 @@ module Sidekiq
     end
 
     get "/scheduled" do
-      @count = (params["count"] || 25).to_i
-      (@current_page, @total_size, @scheduled) = page("schedule", params["page"], @count)
-      @scheduled = @scheduled.map { |msg, score| Sidekiq::SortedEntry.new(nil, score, msg) }
+      x = params[:substr]
+
+      if x && x != ""
+        @scheduled = search(Sidekiq::ScheduledSet.new, x)
+      else
+        @count = (params["count"] || 25).to_i
+        (@current_page, @total_size, @scheduled) = page("schedule", params["page"], @count)
+        @scheduled = @scheduled.map { |msg, score| Sidekiq::SortedEntry.new(nil, score, msg) }
+      end
 
       erb(:scheduled)
     end
@@ -330,33 +348,6 @@ module Sidekiq
 
     get "/stats/queues" do
       json Sidekiq::Stats.new.queues
-    end
-
-    ########
-    # Filtering
-
-    route :get, :post, "/filter/retries" do
-      x = params[:substr]
-      return redirect "#{root_path}retries" unless x && x != ""
-
-      @retries = search(Sidekiq::RetrySet.new, params[:substr])
-      erb :retries
-    end
-
-    route :get, :post, "/filter/scheduled" do
-      x = params[:substr]
-      return redirect "#{root_path}scheduled" unless x && x != ""
-
-      @scheduled = search(Sidekiq::ScheduledSet.new, params[:substr])
-      erb :scheduled
-    end
-
-    route :get, :post, "/filter/dead" do
-      x = params[:substr]
-      return redirect "#{root_path}morgue" unless x && x != ""
-
-      @dead = search(Sidekiq::DeadSet.new, params[:substr])
-      erb :morgue
     end
 
     post "/change_locale" do

--- a/test/filtering_test.rb
+++ b/test/filtering_test.rb
@@ -28,10 +28,12 @@ describe "filtering" do
     add_retry("jid123", "mike")
     add_retry("jid456", "jim")
 
-    get "/filter/retries", substr: ""
-    assert_equal 302, last_response.status
+    get "/retries", substr: ""
+    assert_equal 200, last_response.status
+    assert_includes(last_response.body, "jid123")
+    assert_includes(last_response.body, "jid456")
 
-    post "/filter/retries", substr: "mike"
+    get "/retries", substr: "mike"
     assert_equal 200, last_response.status
     assert_includes(last_response.body, "jid123")
     refute_includes(last_response.body, "jid456")
@@ -41,10 +43,12 @@ describe "filtering" do
     jid1 = FilterJob.perform_in(5, "bob", "tammy")
     jid2 = FilterJob.perform_in(5, "mike", "jim")
 
-    get "/filter/scheduled", substr: ""
-    assert_equal 302, last_response.status
+    get "/scheduled", substr: ""
+    assert_equal 200, last_response.status
+    assert_match(/#{jid1}/, last_response.body)
+    assert_match(/#{jid2}/, last_response.body)
 
-    post "/filter/scheduled", substr: "tammy"
+    get "/scheduled", substr: "tammy"
     assert_equal 200, last_response.status
     assert_match(/#{jid1}/, last_response.body)
     refute_match(/#{jid2}/, last_response.body)
@@ -54,10 +58,12 @@ describe "filtering" do
     add_dead("jid123", "mike")
     add_dead("jid456", "jim")
 
-    get "/filter/dead", substr: ""
-    assert_equal 302, last_response.status
+    get "/morgue", substr: ""
+    assert_equal 200, last_response.status
+    assert_includes(last_response.body, "jid123")
+    assert_includes(last_response.body, "jid456")
 
-    post "/filter/dead", substr: "jim"
+    get "/morgue", substr: "jim"
     assert_equal 200, last_response.status
     refute_includes(last_response.body, "jid123")
     assert_includes(last_response.body, "jid456")

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -1012,14 +1012,11 @@ describe Sidekiq::Web do
       end
 
       it "supports filtering" do
-        get "/filter/metrics"
-        assert_equal 302, last_response.status
-
-        post "/filter/metrics", "substr" => "mike"
+        get "/metrics", "substr" => "mike"
         assert_equal 200, last_response.status
         assert_match(/MikeJob/, last_response.body)
 
-        post "/filter/metrics", "substr" => "notfound"
+        get "/metrics", "substr" => "notfound"
         assert_equal 200, last_response.status
         refute_match(/MikeJob/, last_response.body)
       end

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -1000,8 +1000,9 @@ describe Sidekiq::Web do
         result_mock.expect(:ends_at, Time.now)
 
         query_mock = Minitest::Mock.new
-        query_mock.expect :top_jobs, result_mock do |minutes:|
+        query_mock.expect :top_jobs, result_mock do |minutes:, class_filter:|
           assert_equal minutes, 240
+          assert_nil class_filter
         end
 
         Sidekiq::Metrics::Query.stub :new, query_mock do

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -354,19 +354,13 @@ describe Sidekiq::Web do
     3.times { add_retry }
     add_retry("MIKE1234")
 
-    get "/filter/retries"
-    assert_equal 302, last_response.status
-
-    post "/filter/retries"
-    assert_equal 302, last_response.status
-
-    post "/filter/retries", substr: "nope"
+    get "/retries", substr: "nope"
     refute_match(/RuntimeError/, last_response.body)
 
-    get "/filter/retries", substr: "nope"
+    get "/retries", substr: "nope"
     refute_match(/RuntimeError/, last_response.body)
 
-    post "/filter/retries", substr: "MIKE1234"
+    get "/retries", substr: "MIKE1234"
     assert_match(/MIKE1234/, last_response.body)
   end
 
@@ -472,19 +466,13 @@ describe Sidekiq::Web do
     3.times { add_scheduled }
     add_scheduled("MIKE1234")
 
-    get "/filter/scheduled"
-    assert_equal 302, last_response.status
-
-    post "/filter/scheduled"
-    assert_equal 302, last_response.status
-
-    get "/filter/scheduled", substr: "nope"
+    get "/scheduled", substr: "nope"
     refute_match(/RuntimeError/, last_response.body)
 
-    post "/filter/scheduled", substr: "nope"
+    get "/scheduled", substr: "nope"
     refute_match(/RuntimeError/, last_response.body)
 
-    post "/filter/scheduled", substr: "MIKE1234"
+    get "/scheduled", substr: "MIKE1234"
     assert_match(/MIKE1234/, last_response.body)
   end
 
@@ -766,19 +754,13 @@ describe Sidekiq::Web do
       3.times { add_dead }
       add_dead("MIKE1234")
 
-      get "/filter/dead"
-      assert_equal 302, last_response.status
-
-      post "/filter/dead"
-      assert_equal 302, last_response.status
-
-      post "/filter/dead", substr: "nope"
+      get "/morgue", substr: "nope"
       refute_match(/RuntimeError/, last_response.body)
 
-      get "/filter/dead", substr: "nope"
+      get "/morgue", substr: "nope"
       refute_match(/RuntimeError/, last_response.body)
 
-      post "/filter/dead", substr: "MIKE1234"
+      get "/morgue", substr: "MIKE1234"
       assert_match(/MIKE1234/, last_response.body)
     end
 

--- a/web/views/filtering.erb
+++ b/web/views/filtering.erb
@@ -1,6 +1,5 @@
 <div>
-  <form method="post" class="form-inline" action='<%= root_path %>filter/<%= which %>'>
-    <%= csrf_tag %>
+  <form method="get" class="form-inline" action='<%= root_path %><%= which %>'>
     <label for="substr"><%= t('Filter') %></label>
     <input class="search form-control" type="search" name="substr" value="<%= h params[:substr] %>" placeholder="<%= t('AnyJobContent') %>"/>
   </form>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -9,8 +9,7 @@
   </div>
 
   <div>
-    <form id="metrics-form" class="form-inline" action="<%= root_path %>filter/metrics" method="post">
-      <%= csrf_tag %>
+    <form id="metrics-form" class="form-inline" action="<%= root_path %>metrics" method="get">
       <label for="substr"><%= t('Filter') %></label>
       <input id="class-filter" class="form-control" type="text" name="substr" placeholder="<%= t('Name') %>" value="<%= h params[:substr] %>">
       <select id="period-selector" class="form-control" name="period">


### PR DESCRIPTION
This tackles a small paper cut I've been feeling on Sidekiq's useful Web UI: Applying filters, e.g. to the "Metrics" tab, changes the URL, which breaks reloads. Also, it's not possible to share a permalink to a pre-filtered list.

On the web, filtering a list is usually done with GET requests, using query string parameters. Such an operation does not have side effects, so it can be considered [safe](https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP).

---

Previous, related changes:
- 1b9f7db4c5d0dc41b6eac2682710715eed5aadce
- #6440

---

To test the waters, I only applied this change to the "Metrics" tab. If you like the idea, I will happily and quickly expand the scope to all other tabs with filtering.