### PR TITLE
Change jitter logic to allow full range of possible choices

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -189,7 +189,7 @@ module Sidekiq
 
       # Logging here can break retries if the logging device raises ENOSPC #3979
       # logger.debug { "Failure! Retry #{count} in #{delay} seconds" }
-      jitter = rand(10) * (count + 1)
+      jitter = rand(10 * (count + 1))
       retry_at = Time.now.to_f + delay + jitter
       payload = Sidekiq.dump_json(msg)
       redis do |conn|


### PR DESCRIPTION
I noticed the way the random retry jitter logic was currently set up, there are really only 11 possible values at each retry step.  Even once the `count` has grown and the possible range of jitter values is large, they are still being bucketed into one of the 11 possible values.  I'd like to see a wider range of possible outcomes so that if a large number of jobs all fail at the same time they won't be as clumped together when retrying.

I read your caution about bike shedding in the retry logic, but this just seems like it would produce better results for everyone.  I'm struggling to come up with a scenario where anyone would prefer the current logic of clustering the jitter into 11 distinct buckets at each retry step.

One note, this change would slightly change the average jitter numbers produced.  I'm open to trying to come up with a variation that as closely matches the current results as possible, but wanted to check in first to see both 1. How open you are to this change at all, 2. How much you care about the slight difference in average jitter.

Here are the results of 1000 rounds of trying the original logic vs the PR logic (and 2 other small alternatives I tried) with a `count = 19` value.


  | Current Logic | PR Logic | Alt Logic 1 | Alt Logic 2
-- | -- | -- | -- | --
code | rand(10) * (count + 1) | rand(10 * (count + 1)) | rand(9 * (count + 1)) | rand(10 * (count))
attempts | 1000 | 1000 | 1000 | 1000
mean | 90.70 | 96.78 | 87.07 | 93.64
median | 100 | 93 | 84 | 93
min | 0 | 0 | 0 | 0
max | 180 | 199 | 179 | 189

