### PR TITLE
Better error logging

### DIFF
--- a/lib/sidekiq/config.rb
+++ b/lib/sidekiq/config.rb
@@ -47,7 +47,7 @@ module Sidekiq
           end
         else
           cfg.logger.info do
-            ex.detailed_message(highlight: fancy).tr("\n", " ")
+            ex.detailed_message(highlight: fancy)
           end
         end
       end

--- a/lib/sidekiq/config.rb
+++ b/lib/sidekiq/config.rb
@@ -39,12 +39,17 @@ module Sidekiq
     }
 
     ERROR_HANDLER = ->(ex, ctx, cfg = Sidekiq.default_configuration) {
-      l = cfg.logger
-      l.warn(Sidekiq.dump_json(ctx)) unless ctx.empty?
-      l.warn("#{ex.class.name}: #{ex.message}")
-      unless ex.backtrace.nil?
-        backtrace = cfg[:backtrace_cleaner].call(ex.backtrace)
-        l.warn(backtrace.join("\n"))
+      Sidekiq::Context.with(ctx) do
+        fancy = cfg[:environment] == "development" && $stdout.tty?
+        if cfg.logger.debug?
+          cfg.logger.debug do
+            ex.full_message(highlight: fancy)
+          end
+        else
+          cfg.logger.info do
+            ex.detailed_message(highlight: fancy).tr("\n", " ")
+          end
+        end
       end
     }
 

--- a/lib/sidekiq/logger.rb
+++ b/lib/sidekiq/logger.rb
@@ -84,7 +84,12 @@ module Sidekiq
         def format_context(ctxt = Sidekiq::Context.current)
           if ctxt.size > 0
             ctxt.map { |k, v|
-              "#{k}=#{Sidekiq.dump_json(v)}"
+              case v
+              when Array
+                "#{k}=#{v.join(",")}"
+              else
+                "#{k}=#{v}"
+              end
             }.join(" ")
           end
         end

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -113,7 +113,6 @@ module Sidekiq
     def handle_fetch_exception(ex)
       unless @down
         @down = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
-        logger.error("Error fetching job: #{ex}")
         handle_exception(ex)
       end
       sleep(1)
@@ -173,7 +172,6 @@ module Sidekiq
       begin
         job_hash = Sidekiq.load_json(jobstr)
       rescue => ex
-        handle_exception(ex, {context: "Invalid JSON for job", jobstr: jobstr})
         now = Time.now.to_f
         redis do |conn|
           conn.multi do |xa|
@@ -182,6 +180,7 @@ module Sidekiq
             xa.zremrangebyrank("dead", 0, - @capsule.config[:dead_max_jobs])
           end
         end
+        handle_exception(ex, {context: "Invalid JSON for job", jobstr: jobstr})
         return uow.acknowledge
       end
 

--- a/test/exception_handler_test.rb
+++ b/test/exception_handler_test.rb
@@ -65,11 +65,10 @@ describe Sidekiq::Component do
     end
 
     it "logs the exception to Sidekiq.logger" do
-      @config[:reloader] = Sidekiq::Rails::Reloader.new
-      output = capture_logging(@config) do
+      output = capture_logging(@config, :debug) do
         Thing.new(@config).invoke_exception(a: 1)
       end
-      assert_match(/"a":1/, output, "didn't include the context")
+      assert_match(/a=1/, output, "didn't include the context")
       assert_match(/Something didn't work!/, output, "didn't include the exception message")
       assert_match(/test\/exception_handler_test.rb/, output, "didn't include the backtrace")
     end
@@ -89,17 +88,6 @@ describe Sidekiq::Component do
       ensure
         @config[:error_handlers].delete(test_handler)
       end
-    end
-
-    it "cleans a backtrace if there is a cleaner" do
-      @config[:backtrace_cleaner] = ->(backtrace) { backtrace.take(1) }
-      output = capture_logging(@config) do
-        Thing.new(@config).invoke_exception(a: 1)
-      end
-
-      assert_equal 1, output.lines.count { |line| line.match?(/\d+:in/) }
-    ensure
-      @config[:backtrace_cleaner] = Sidekiq::Config::DEFAULTS[:backtrace_cleaner]
     end
 
     describe "when the exception does not have a backtrace" do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -49,6 +49,7 @@ def capture_logging(cfg, lvl = Logger::INFO)
     out = StringIO.new
     logger = ::Logger.new(out)
     logger.level = lvl
+    logger.formatter = Sidekiq::Logger::Formatters::Pretty.new
     cfg.logger = logger
     yield logger
     out.string


### PR DESCRIPTION
Adjust default error reporter to use newer Ruby APIs and provide the full error backtrace in :debug.

## Error Logging

With log level `:info`, Sidekiq will display the exception's message and any detailed context. For instance a JSON::GeneratorError will include the invalid object which triggered the error.

With log level `:debug`, Sidekiq will also include the backtrace of the error. Unfortunately because the backtrace is formatted in `Exception#full_message`, we lose the ability to clean/prune the error's backtrace, a la Rails. In my experience it's better to see the full trace anyhow.

The backtrace cleaner will still be available to trim the `error_backtrace` element stored within retries.

Fixes #6518