### PR TITLE
Add emoji flag to locale dropdown

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -95,6 +95,10 @@ module Sidekiq
       locale_files.select { |file| file =~ /\/#{lang}\.yml$/ }
     end
 
+    def language_name(locale)
+      strings(locale).fetch("LanguageName", locale)
+    end
+
     def search(jobset, substr)
       resultset = jobset.scan(substr).to_a
       @current_page = 1

--- a/test/web_helpers_test.rb
+++ b/test/web_helpers_test.rb
@@ -110,6 +110,13 @@ describe "Web helpers" do
     assert_equal "en", obj.locale
   end
 
+  it "returns language name from locale" do
+    obj = Helpers.new
+    assert_equal "English", obj.language_name("en")
+    assert_equal "Português", obj.language_name("pt")
+    assert_equal "missing", obj.language_name("missing")
+  end
+
   it "handles invalid locales" do
     obj = Helpers.new("HTTP_ACCEPT_LANGUAGE" => "*")
     obj.instance_eval do

--- a/web/locales/ar.yml
+++ b/web/locales/ar.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 ar:
+  LanguageName: العربية
   Actions: إجراءات
   AddToQueue: إضافة إلى الرتل
   AreYouSure: هل انت متأكد؟

--- a/web/locales/cs.yml
+++ b/web/locales/cs.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 cs:
+  LanguageName: Čeština
   Actions: Akce
   AddToQueue: Přidat do fronty
   AreYouSure: Jste si jisti?

--- a/web/locales/da.yml
+++ b/web/locales/da.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 da:
+  LanguageName: Dansk
   Actions: Handlinger
   AddToQueue: Tilføj til kø
   AreYouSure: Er du sikker?

--- a/web/locales/de.yml
+++ b/web/locales/de.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 de:
+  LanguageName: Deutsch
   Actions: Aktionen
   AddToQueue: In Warteschlange einreihen
   AreYouSure: Bist du sicher?

--- a/web/locales/el.yml
+++ b/web/locales/el.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 el: # <---- change this to your locale code
+  LanguageName: ελληνικά
   Dashboard: Πίνακας Ελέγχου
   Status: Κατάσταση
   Time: Χρόνος

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 en:
+  LanguageName: English
   Actions: Actions
   AddToQueue: Add to queue
   AreYouSure: Are you sure?

--- a/web/locales/es.yml
+++ b/web/locales/es.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 es:
+  LanguageName: Español
   Actions: Acciones
   AddToQueue: Añadir a la cola
   AreYouSure: ¿Estás seguro?

--- a/web/locales/fa.yml
+++ b/web/locales/fa.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 fa:
+  LanguageName: فارسى
   Actions: اعمال
   AddToQueue: افزودن به صف
   AreYouSure: آیا مطمعن هستید?

--- a/web/locales/fr.yml
+++ b/web/locales/fr.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 fr:
+  LanguageName: Français
   Actions: Actions
   AddToQueue: Ajouter à la queue
   AreYouSure: Êtes-vous certain ?

--- a/web/locales/gd.yml
+++ b/web/locales/gd.yml
@@ -1,5 +1,6 @@
 ﻿# elements like %{queue} are variables and should not be translated
 gd:
+  LanguageName: Gaeilge
   Actions: Gnìomhan
   AddToQueue: Cuir ris a’ chiutha
   AreYouSure: A bheil thu cinnteach?

--- a/web/locales/he.yml
+++ b/web/locales/he.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 he:
+  LanguageName: עברית
   Actions: פעולות
   AddToQueue: הוסף לתור
   AreYouSure: אתם בטוחים?

--- a/web/locales/hi.yml
+++ b/web/locales/hi.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 hi:
+  LanguageName: हिन्दी
   Actions: कार्रवाई
   AddToQueue: कतार मे जोड़ें
   AreYouSure: क्या आपको यकीन है?

--- a/web/locales/it.yml
+++ b/web/locales/it.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 it:
+  LanguageName: Italiano
   Actions: Azioni
   AddToQueue: Aggiungi alla coda
   AreYouSure: Sei sicuro?

--- a/web/locales/ja.yml
+++ b/web/locales/ja.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 ja:
+  LanguageName: 日本語
   Actions: アクション
   AddToQueue: キューに追加
   AreYouSure: よろしいですか？

--- a/web/locales/ko.yml
+++ b/web/locales/ko.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 ko:
+  LanguageName: 한국어
   Actions: 동작
   AddToQueue: 큐 추가
   AreYouSure: 정말입니까?

--- a/web/locales/lt.yml
+++ b/web/locales/lt.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 lt:
+  LanguageName: Lietuvių
   Actions: Veiksmai
   AddToQueue: Pridėti į eilę
   AreYouSure: Ar jūs įsitikinę?

--- a/web/locales/nb.yml
+++ b/web/locales/nb.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 nb:
+  LanguageName: Norsk
   Actions: Handlinger
   AddToQueue: Legg til i kø
   AreYouSure: Er du sikker?

--- a/web/locales/nl.yml
+++ b/web/locales/nl.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 nl:
+  LanguageName: Nederlands
   Actions: Acties
   AddToQueue: Toevoegen aan wachtrij
   AreYouSure: Weet u het zeker?

--- a/web/locales/pl.yml
+++ b/web/locales/pl.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 pl:
+  LanguageName: Polski
   Actions: Akcje
   AddToQueue: dodaj do kolejki
   AreYouSure: Na pewno?

--- a/web/locales/pt-br.yml
+++ b/web/locales/pt-br.yml
@@ -1,4 +1,5 @@
 "pt-br":
+  LanguageName: Português (Brasil)
   Actions: Ações
   AddToQueue: Adicionar à fila
   AreYouSure: Tem certeza?

--- a/web/locales/pt.yml
+++ b/web/locales/pt.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 pt:
+  LanguageName: Português
   Actions: Acções
   AddToQueue: Adicionar à fila
   AreYouSure: Tem a certeza?

--- a/web/locales/ru.yml
+++ b/web/locales/ru.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 ru:
+  LanguageName: Русский
   Actions: Действия
   AddToQueue: Добавить в очередь
   AreYouSure: Вы уверены?

--- a/web/locales/sv.yml
+++ b/web/locales/sv.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 sv:
+  LanguageName: Svenska
   Actions: Åtgärder
   AddToQueue: Lägg till i kö
   AreYouSure: Är du säker?

--- a/web/locales/ta.yml
+++ b/web/locales/ta.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 ta:
+  LanguageName: தமிழ்
   Actions: செயல்கள்
   AddToQueue: வரிசையில் சேர்
   AreYouSure: நீங்கள் உறுதியாக இருக்கிறீர்களா?

--- a/web/locales/tr.yml
+++ b/web/locales/tr.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 tr:
+  LanguageName: Türkçe
   Actions: Eylemler
   AddToQueue: Kuyruğa ekle
   AreYouSure: Emin misiniz?

--- a/web/locales/uk.yml
+++ b/web/locales/uk.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 uk:
+  LanguageName: Українська
   Actions: Дії
   AddToQueue: Додати до черги
   AreYouSure: Ви впевнені?

--- a/web/locales/ur.yml
+++ b/web/locales/ur.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 ur:
+  LanguageName: اردو
   Actions: ﻋﻮاﻣﻞ
   AddToQueue: ﻗﻄﺎﺭ ميں شامل کريں
   AreYouSure: کيا یقین ؟

--- a/web/locales/vi.yml
+++ b/web/locales/vi.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 vi:
+  LanguageName: Tiếng Việt
   Actions: Những hành động
   AddToQueue: Thêm vào hàng đợi
   AreYouSure: Bạn chắc chứ?

--- a/web/locales/zh-cn.yml
+++ b/web/locales/zh-cn.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 zh-cn: # <---- change this to your locale code
+  LanguageName: 中文
   Dashboard: 信息板
   Status: 状态
   Time: 时间

--- a/web/locales/zh-tw.yml
+++ b/web/locales/zh-tw.yml
@@ -1,5 +1,6 @@
 # elements like %{queue} are variables and should not be translated
 zh-tw: # <---- change this to your locale code
+  LanguageName: 臺灣話
   Dashboard: 資訊主頁
   Status: 狀態
   Time: 時間

--- a/web/views/_footer.erb
+++ b/web/views/_footer.erb
@@ -21,9 +21,9 @@
               <select id="locale-select" class="form-control" name="locale">
                 <% available_locales.each do |locale_option| %>
                   <% if locale_option == locale %>
-                    <option selected value="<%= locale_option %>"><%= locale_option %></option>
+                    <option selected value="<%= locale_option %>"><%= language_name(locale_option) %></option>
                   <% else %>
-                    <option value="<%= locale_option %>"><%= locale_option %></option>
+                    <option value="<%= locale_option %>"><%= language_name(locale_option) %></option>
                   <% end %>
                 <% end %>
               </select>


### PR DESCRIPTION
Closes #6520.

<img width="121" alt="Screenshot 2024-11-26 at 15 08 16" src="https://github.com/user-attachments/assets/2bd76dc9-0252-47a4-8433-2dbf5bd0f006">

.
.
Links that were useful:
* [List of locales](https://help.sap.com/docs/SAP_BUSINESSOBJECTS_BUSINESS_INTELLIGENCE_PLATFORM/09382741061c40a989fae01e61d54202/46758c5e6e041014910aba7db0e91070.html)
* [List of country codes](https://en.wikipedia.org/wiki/ISO_3166-1)
* https://dev.to/ionbazan/turn-a-country-code-into-an-emoji-flag-us--360a
