### PR TITLE
Delete Rack 2 code leftovers

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -44,19 +44,11 @@ module Sidekiq
       store_url: "https://api.profiler.firefox.com/compressed-store"
     }
 
-    if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3")
-      CONTENT_LANGUAGE = "Content-Language"
-      CONTENT_SECURITY_POLICY = "Content-Security-Policy"
-      LOCATION = "Location"
-      X_CASCADE = "X-Cascade"
-      X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options"
-    else
-      CONTENT_LANGUAGE = "content-language"
-      CONTENT_SECURITY_POLICY = "content-security-policy"
-      LOCATION = "location"
-      X_CASCADE = "x-cascade"
-      X_CONTENT_TYPE_OPTIONS = "x-content-type-options"
-    end
+    CONTENT_LANGUAGE = "content-language"
+    CONTENT_SECURITY_POLICY = "content-security-policy"
+    LOCATION = "location"
+    X_CASCADE = "x-cascade"
+    X_CONTENT_TYPE_OPTIONS = "x-content-type-options"
 
     class << self
       def settings


### PR DESCRIPTION
Closes #6441.

Rack 3 is already a requirement since https://github.com/sidekiq/sidekiq/commit/13146d5756415b4b5135058b6f960ed11c51a0b2#diff-3c96c10e9d8be1adc6e87508d8ee4715a571a33403e246a02b63206b818bc1c9R28