### PR TITLE
Make queue latency always float even if there's no job entry

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -105,7 +105,7 @@ module Sidekiq
         thence = job["enqueued_at"] || now
         now - thence
       else
-        0
+        0.0
       end
 
       @stats = {
@@ -265,7 +265,7 @@ module Sidekiq
       entry = Sidekiq.redis { |conn|
         conn.lindex(@rname, -1)
       }
-      return 0 unless entry
+      return 0.0 unless entry
       job = Sidekiq.load_json(entry)
       now = Time.now.to_f
       thence = job["enqueued_at"] || now

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -51,6 +51,7 @@ describe "API" do
       assert_equal 0, s.failed
       assert_equal 0, s.enqueued
       assert_equal 0, s.default_queue_latency
+      assert_kind_of Float, s.default_queue_latency
       assert_equal 0, s.workers_size
     end
 
@@ -244,6 +245,7 @@ describe "API" do
       q = Sidekiq::Queue.new
       assert_equal 0, q.size
       assert_equal 0, q.latency
+      assert_kind_of Float, q.latency
     end
 
     before do


### PR DESCRIPTION
According to the documentation, `#latency` returns Float.

> Returns:
> (Float) — in seconds
> https://www.rubydoc.info/github/mperham/sidekiq/Sidekiq%2FQueue:latency

But, it returns integer 0 when there's no job entry.  
This behavior is problematic when you want to send `#latency` to somewhere that require type definition.
I have faced this problem when I tried to send latency to [Google Cloud Metrics](https://cloud.google.com/monitoring/api/metrics_gcp)

This PR makes `#latency` to send float 0.0 even if there's no job entry.
