### PR TITLE
Enhance Language Code Consistency for Internationalization

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -154,7 +154,7 @@ module Sidekiq
     # See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
     def user_preferred_languages
       languages = env["HTTP_ACCEPT_LANGUAGE"]
-      languages.to_s.downcase.gsub(/\s+/, "").split(",").map { |language|
+      languages.to_s.gsub(/\s+/, "").split(",").map { |language|
         locale, quality = language.split(";q=", 2)
         locale = nil if locale == "*" # Ignore wildcards
         quality = quality ? quality.to_f : 1.0
@@ -173,7 +173,13 @@ module Sidekiq
       @locale ||= if (l = session&.fetch(:locale, nil)) && available_locales.include?(l)
         l
       else
+
+        # exactly match with preferred like "pt-BR, zh-CN, zh-TW..." first
         matched_locale = user_preferred_languages.map { |preferred|
+          available_locales.include?(preferred) if preferred.length == 5
+        }
+
+        matched_locale ||= user_preferred_languages.map { |preferred|
           preferred_language = preferred.split("-", 2).first
 
           lang_group = available_locales.select { |available|

--- a/test/web_helpers_test.rb
+++ b/test/web_helpers_test.rb
@@ -70,7 +70,10 @@ describe "Web helpers" do
     assert_equal "fr", obj.locale
 
     obj = Helpers.new("HTTP_ACCEPT_LANGUAGE" => "zh-CN,zh;q=0.8,en-US;q=0.6,en;q=0.4,ru;q=0.2")
-    assert_equal "zh-cn", obj.locale
+    assert_equal "zh-CN", obj.locale
+
+    obj = Helpers.new("HTTP_ACCEPT_LANGUAGE" => "zh-TW,zh;q=0.8,en-US;q=0.6,en;q=0.4,ru;q=0.2")
+    assert_equal "zh-TW", obj.locale
 
     obj = Helpers.new("HTTP_ACCEPT_LANGUAGE" => "en-US,sv-SE;q=0.8,sv;q=0.6,en;q=0.4")
     assert_equal "en", obj.locale
@@ -85,13 +88,13 @@ describe "Web helpers" do
     assert_equal "sv", obj.locale
 
     obj = Helpers.new("HTTP_ACCEPT_LANGUAGE" => "pt-BR,pt;q=0.8,en-US;q=0.6,en;q=0.4")
-    assert_equal "pt-br", obj.locale
+    assert_equal "pt-BR", obj.locale
 
     obj = Helpers.new("HTTP_ACCEPT_LANGUAGE" => "pt-PT,pt;q=0.8,en-US;q=0.6,en;q=0.4")
     assert_equal "pt", obj.locale
 
     obj = Helpers.new("HTTP_ACCEPT_LANGUAGE" => "pt-br")
-    assert_equal "pt-br", obj.locale
+    assert_equal "pt", obj.locale
 
     obj = Helpers.new("HTTP_ACCEPT_LANGUAGE" => "pt-pt")
     assert_equal "pt", obj.locale
@@ -149,8 +152,8 @@ describe "Web helpers" do
     obj = Helpers.new
     expected = %w[
       ar cs da de el en es fa fr gd he hi it ja
-      ko lt nb nl pl pt pt-br ru sv ta tr uk ur
-      vi zh-cn zh-tw
+      ko lt nb nl pl pt pt-BR ru sv ta tr uk ur
+      vi zh-CN zh-TW
     ]
     assert_equal expected, obj.available_locales.sort
   end

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -58,10 +58,10 @@ describe Sidekiq::Web do
     rackenv = {"HTTP_ACCEPT_LANGUAGE" => "en-us"}
     get "/", {}, rackenv
     assert_match(/Dashboard/, last_response.body)
-    rackenv = {"HTTP_ACCEPT_LANGUAGE" => "zh-cn"}
+    rackenv = {"HTTP_ACCEPT_LANGUAGE" => "zh-CN"}
     get "/", {}, rackenv
     assert_match(/信息板/, last_response.body)
-    rackenv = {"HTTP_ACCEPT_LANGUAGE" => "zh-tw"}
+    rackenv = {"HTTP_ACCEPT_LANGUAGE" => "zh-TW"}
     get "/", {}, rackenv
     assert_match(/資訊主頁/, last_response.body)
     rackenv = {"HTTP_ACCEPT_LANGUAGE" => "nb"}

--- a/web/locales/pt-br.yml
+++ b/web/locales/pt-br.yml
@@ -1,4 +1,4 @@
-"pt-br":
+"pt-BR":
   LanguageName: Português (Brasil)
   Actions: Ações
   AddToQueue: Adicionar à fila

--- a/web/locales/zh-cn.yml
+++ b/web/locales/zh-cn.yml
@@ -1,5 +1,5 @@
 # elements like %{queue} are variables and should not be translated
-zh-cn: # <---- change this to your locale code
+zh-CN: # <---- change this to your locale code
   LanguageName: 中文
   Dashboard: 信息板
   Status: 状态

--- a/web/locales/zh-tw.yml
+++ b/web/locales/zh-tw.yml
@@ -1,5 +1,5 @@
 # elements like %{queue} are variables and should not be translated
-zh-tw: # <---- change this to your locale code
+zh-TW: # <---- change this to your locale code
   LanguageName: 臺灣話
   Dashboard: 資訊主頁
   Status: 狀態


### PR DESCRIPTION
This pull request aims to standardize and enhance the compatibility of language codes across our application. By changing the following language codes to their more widely accepted forms like `rails-i18n` gem:

`pt-br` to `pt-BR`
`zh-cn` to `zh-CN`
`zh-tw` to `zh-TW`
We ensure that our internationalization efforts are more uniform and consistent, which is particularly important when integrating with tools like sidekiq-cron. This change prevents the confusion that can arise from having two seemingly different codes (`zh-cn` and `zh-CN`) both representing Simplified Chinese. By adopting a single, standardized code for each language, we streamline our localization process and improve the user experience for international users.