### PR TITLE
Change Sidekiq's default thread priority to -1

### DIFF
--- a/lib/sidekiq/capsule.rb
+++ b/lib/sidekiq/capsule.rb
@@ -27,7 +27,7 @@ module Sidekiq
     attr_reader :mode
     attr_reader :weights
 
-    def_delegators :@config, :[], :[]=, :fetch, :key?, :has_key?, :merge!, :dig
+    def_delegators :@config, :[], :[]=, :fetch, :key?, :has_key?, :merge!, :dig, :thread_priority
 
     def initialize(name, config)
       @name = name

--- a/lib/sidekiq/config.rb
+++ b/lib/sidekiq/config.rb
@@ -63,6 +63,7 @@ module Sidekiq
 
     def_delegators :@options, :[], :[]=, :fetch, :key?, :has_key?, :merge!, :dig
     attr_reader :capsules
+    attr_accessor :thread_priority
 
     def to_json(*)
       Sidekiq.dump_json(@options)

--- a/test/actors_test.rb
+++ b/test/actors_test.rb
@@ -19,6 +19,7 @@ end
 describe "Actors" do
   before do
     @config = reset!
+    @config.thread_priority = 0
     @cap = @config.default_capsule
   end
 

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -73,6 +73,7 @@ describe Sidekiq::Processor do
   before do
     $invokes = 0
     @config = reset!
+    @config.thread_priority = 0
     @processor = ::Sidekiq::Processor.new(@config.default_capsule) { |*args| }
   end
 


### PR DESCRIPTION
Ruby's default 100ms timeslice can cause significant delays in threading if the user has configured high concurrency with CPU heavy jobs (e.g. the old Sidekiq default of 25 threads). Worst case, each of those 25 threads can wait 2.5 seconds before they get back on the CPU. Now imagine an IO timeout set for 1 second -- it's quite possible to see random TimeoutErrors due to timeslice starvation.

This PR adjusts the default Thread.priority for all Sidekiq threads to be -1, or a 50ms timeslice. -2 would use a 25ms slice.

The user can adjust the priority like so:

```ruby
Sidekiq.configure_server do |cfg|
  # I don't recommend setting any values besides -2, -1 and 0.
  # 0 is Ruby's default, -1 is Sidekiq's default.
  cfg.thread_priority = 0
end
```

See also https://github.com/bensheldon/good_job/issues/1554