### PR TITLE
push bulk with dynamic queues

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -269,14 +269,16 @@ module Sidekiq
           [at, Sidekiq.dump_json(hash)]
         })
       else
-        queue = payloads.first["queue"]
-        now = Time.now.to_f
-        to_push = payloads.map { |entry|
-          entry["enqueued_at"] = now
-          Sidekiq.dump_json(entry)
-        }
-        conn.sadd("queues", [queue])
-        conn.lpush("queue:#{queue}", to_push)
+        grouped_queues = payloads.group_by { |job| job["queue"] }
+        grouped_queues.each do |queue, grouped_payloads|
+          now = Time.now.to_f
+          to_push = grouped_payloads.map { |entry|
+            entry["enqueued_at"] = now
+            Sidekiq.dump_json(entry)
+          }
+          conn.sadd("queues", [queue])
+          conn.lpush("queue:#{queue}", to_push)
+        end
       end
     end
   end

--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -269,14 +269,14 @@ module Sidekiq
           [at, Sidekiq.dump_json(hash)]
         })
       else
+        now = Time.now.to_f
         grouped_queues = payloads.group_by { |job| job["queue"] }
+        conn.sadd("queues", grouped_queues.keys)
         grouped_queues.each do |queue, grouped_payloads|
-          now = Time.now.to_f
           to_push = grouped_payloads.map { |entry|
             entry["enqueued_at"] = now
             Sidekiq.dump_json(entry)
           }
-          conn.sadd("queues", [queue])
           conn.lpush("queue:#{queue}", to_push)
         end
       end


### PR DESCRIPTION
This PR changes the way `atomic_push` chooses the queue to send payloads. Instead of taking the first one, it regroups payloads by queue and dispatch them. Fix #6546