### PR TITLE
Use String#b to create a mutable binary string

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -149,7 +149,7 @@ module Sidekiq
 
       m = exception_message(exception)
       if m.respond_to?(:scrub!)
-        m.force_encoding("utf-8")
+        m.force_encoding(Encoding::UTF_8)
         m.scrub!
       end
 

--- a/test/profiling_test.rb
+++ b/test/profiling_test.rb
@@ -46,8 +46,7 @@ describe "profiling" do
     assert_equal %w[bob-5678 mike-1234], profiles.map(&:key)
     assert_equal %w[5678 1234], profiles.map(&:jid)
 
-    header = +"\x1f\x8b"
-    header.force_encoding("BINARY")
+    header = "\x1f\x8b".b
     profiles.each do |pr|
       assert pr.started_at
       assert_operator pr.size, :>, 2


### PR DESCRIPTION
I just saw: https://bugs.ruby-lang.org/issues/20966

`String#b` is the most convenient method to create a mutable binary string.

I also replaced encoding strings by the actual constants.