### PR TITLE
Add second link to error details from morgue and retries list

### DIFF
--- a/web/views/morgue.erb
+++ b/web/views/morgue.erb
@@ -48,7 +48,7 @@
               </td>
               <td>
                 <% if entry.error? %>
-                <div><%= h truncate("#{entry['error_class']}: #{entry['error_message']}", 200) %></div>
+                  <div><a href="<%= root_path %>morgue/<%= job_params(entry.item, entry.score) %>"><%= h truncate("#{entry['error_class']}: #{entry['error_message']}", 200) %></a></div>
                 <% end %>
               </td>
             </tr>

--- a/web/views/retries.erb
+++ b/web/views/retries.erb
@@ -51,7 +51,7 @@
                 </code>
               </td>
               <td>
-                <div><%= h truncate("#{entry['error_class']}: #{entry['error_message']}", 200) %></div>
+                <div><a href="<%= root_path %>retries/<%= job_params(entry.item, entry.score) %>"><%= h truncate("#{entry['error_class']}: #{entry['error_message']}", 200) %></a></div>
               </td>
             </tr>
           <% end %>


### PR DESCRIPTION
Resolves #6581 

## Purpose
From a UX perspective, it is not immediately intuitive to click on this time information to get error details.

## Approach
Add a second link to the Error column.

## Testing
Ran locally.

## Video

https://github.com/user-attachments/assets/c4357d44-670e-4f35-aa44-ebecadf0db0f

https://github.com/user-attachments/assets/ef28b4be-3d4e-4cc8-b589-0cf3f63aade5



