### PR TITLE
Revert "Preload AJ adapter so we can always find S::AJ::Wrapper base class"

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -38,9 +38,9 @@ module Sidekiq
     #     end
     #   end
     initializer "sidekiq.active_job_integration" do
-      require "active_job/queue_adapters/sidekiq_adapter"
-
       ActiveSupport.on_load(:active_job) do
+        require "active_job/queue_adapters/sidekiq_adapter"
+
         include ::Sidekiq::Job::Options unless respond_to?(:sidekiq_options)
       end
     end


### PR DESCRIPTION
fixed: #6584


This reverts commit 4203f28b7e3468dff5742a745a42cf344830ad52.