### PR TITLE
Fix iterable jobs cancellation

### DIFF
--- a/lib/sidekiq/job/iterable.rb
+++ b/lib/sidekiq/job/iterable.rb
@@ -198,7 +198,7 @@ module Sidekiq
           if ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - state_flushed_at >= STATE_FLUSH_INTERVAL || is_interrupted
             _, _, cancelled = flush_state
             state_flushed_at = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
-            if cancelled == 1
+            if cancelled
               @_cancelled = true
               logger.info { "Job cancelled" }
               return true


### PR DESCRIPTION
Currently, cancelling an iterable job works only when the job was interrupted and it starts again. In this case the cancellation flag is checked correctly.

When the job is running, the flag's value is checked incorrectly, because it is set to a timestamp in the codebase.
https://github.com/sidekiq/sidekiq/blob/6a360285c146628d6332bf4a68d85c419330c27d/lib/sidekiq/client.rb#L68

I haven't added tests, because looks like it will be particularly hard to test this case (the test case should at least use a new interrupting thread).