### PR TITLE
Expose current cursor inside iterable jobs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ HEAD / main
 - Freshen up `Sidekiq::Web` to simplify the code and improve security [#6532]
   The CSS has been rewritten from scratch to remove the Bootstrap framework.
 - Add `on_cancel` callback for iterable jobs [#6607]
+- Add `cursor` reader to get the current cursor inside iterable jobs [#6606]
 - Default error logging has been modified to use Ruby's `Exception#detailed_message` and `#full_message` APIs.
 - CI now runs against Redis, Dragonfly and Valkey.
 - Job tags now allow custom CSS display [#6595]

--- a/lib/sidekiq/job/iterable.rb
+++ b/lib/sidekiq/job/iterable.rb
@@ -64,6 +64,10 @@ module Sidekiq
         @_cancelled
       end
 
+      def cursor
+        @_cursor.freeze
+      end
+
       # A hook to override that will be called when the job starts iterating.
       #
       # It is called only once, for the first time.


### PR DESCRIPTION
I need to have access to the current cursor inside the iterable job, to store it externally (basically a db table row with some metadata about the iterable job). Currently, can access it only via an instance variable.