### PR TITLE
Fix accessibility issues

### DIFF
--- a/web/assets/stylesheets/style.css
+++ b/web/assets/stylesheets/style.css
@@ -557,7 +557,7 @@ body > footer .nav {
 @media (prefers-color-scheme: dark) {
   :root {
     /* --color-primary: oklch(65% 0.15 13); */
-    --color-primary: oklch(60% 0.22 13);
+    --color-primary: oklch(65% 0.22 13);
     --color-bg: oklch(22% 0.01 256);
     --color-elevated: oklch(19% 0.01 256);
     --color-border: oklch(25% 0.01 256);

--- a/web/views/_nav.erb
+++ b/web/views/_nav.erb
@@ -17,7 +17,7 @@
       </a>
     </div>
 
-    <div class="navbar-collapse" id="navbar-menu">
+    <div class="navbar-collapse" role="navigation" id="navbar-menu">
       <ul class="nav" data-navbar="static">
         <% config.tabs.each do |title, url| %>
           <% if url == '' %>

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html dir="<%= text_direction %>">
+<html dir="<%= text_direction %>" lang="<%= locale %>">
   <head>
     <title><%= environment_title_prefix %><%= Sidekiq::NAME %></title>
     <meta charset="utf-8" />


### PR DESCRIPTION
Fixes two minor accessibility issues. Violations:
- `<html> element must have a lang attribute`
- `<li> elements must be contained n a <ul> or <ol>`
- `Elements must meet minimum color contrast ratio thresholds`

## `<html> element must have a lang attribute`

`ul` can't have the `role` navigation but it's parent can. It is expected that the contained `<li>`'s are on a `role="list"` but it has `role="navigation"` set. We can easily solve this violation by moving the `role` to the parent `div`.

See also this example here: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role#examples

## `<li> elements must be contained n a <ul> or <ol>`

The language (`lang`) attribute is missing on the `html` tag. Adding the `lang` attribute to the `html` element will fix this small issue.

## `Elements must meet minimum color contrast ratio thresholds`

This is only fixable if you would change your primary color in darkmode. A possible solution is to alter the color in darkmode slightly to achieve a 4.5:1 contrast ratio to pass WCAG 2 AA minimum contrast

`oklch(60% 0.22 13)` (3.73:1) -> `oklch(65% 0.22 13)` (4.59:1)

## How to reproduce

The easiest way to reproduce these a11y issues is to:
1. Install the Axe a11y browser extension: https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd
2. Run an site audit
3. Look at the violations

Best wishes from your friends over at GitLab 👋