### PR TITLE
Update scrub method to properly handle password as a Proc

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -57,13 +57,13 @@ module Sidekiq
         # Deep clone so we can muck with these options all we want and exclude
         # params from dump-and-load that may contain objects that Marshal is
         # unable to safely dump.
-        keys = options.keys - [:logger, :ssl_params]
+        keys = options.keys - [:logger, :ssl_params, :password]
         scrubbed_options = Marshal.load(Marshal.dump(options.slice(*keys)))
         if scrubbed_options[:url] && (uri = URI.parse(scrubbed_options[:url])) && uri.password
           uri.password = redacted
           scrubbed_options[:url] = uri.to_s
         end
-        scrubbed_options[:password] = redacted if scrubbed_options[:password]
+        scrubbed_options[:password] = redacted if options.key?(:password)
         scrubbed_options[:sentinel_password] = redacted if scrubbed_options[:sentinel_password]
         scrubbed_options[:sentinels]&.each do |sentinel|
           if sentinel.is_a?(String)


### PR DESCRIPTION
Fixes: https://github.com/sidekiq/sidekiq/issues/6624.
This change is needed to allow passing a proc in as password, which is the best way to do IAM auth with ElastiCache.

It would be great if this could be included as part of 7.3.x (preferred) or 7.4.x