### PR TITLE
Add dragonfly version tags to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         database: [
           { image: "redis", version: "7.2.4" }, # last BSD-licensed version
           { image: "valkey/valkey", version: "8" },
-          { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "v1.26.0" },
+          { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "v1.27.0" },
           { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "latest" }
         ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         database: [
           { image: "redis", version: "7.2.4" }, # last BSD-licensed version
           { image: "valkey/valkey", version: "8" },
-          { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "v1.13.0" },
+          { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "v1.26.0" },
           { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "latest" }
         ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         database: [
           { image: "redis", version: "7.2.4" }, # last BSD-licensed version
           { image: "valkey/valkey", version: "8" },
-          # dragonfly doesn't publish any version tags aside from "latest", seems bad man
-          { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "latest" } 
+          { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "v1.13.0" },
+          { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "latest" }
         ]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ same process. Sidekiq can be used by any Ruby application.
 Requirements
 -----------------
 
-- Redis: Redis 7.2+, Valkey 7.2+ or Dragonfly 1.26+
+- Redis: Redis 7.2+, Valkey 7.2+ or Dragonfly 1.27+
 - Ruby: MRI 3.2+ or JRuby 9.4+.
 
 Sidekiq 8.0 supports Rails and Active Job 7.0+.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ same process. Sidekiq can be used by any Ruby application.
 Requirements
 -----------------
 
-- Redis: Redis 7.2+, Valkey 7.2+ or Dragonfly 1.13+
+- Redis: Redis 7.2+, Valkey 7.2+ or Dragonfly 1.26+
 - Ruby: MRI 3.2+ or JRuby 9.4+.
 
 Sidekiq 8.0 supports Rails and Active Job 7.0+.


### PR DESCRIPTION
Dragonfly does publish tags to docker builds:
https://github.com/dragonflydb/dragonfly/discussions/3233

Add the minimum supported version to CI - `1.13+` as per README.