### PR TITLE
Drop Redis to 7.0 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         ruby: ["ruby-3.2", "ruby-3.3", "ruby-3.4"]
         database: [
-          { image: "redis", version: "7.2.4" }, # last BSD-licensed version
+          { image: "redis", version: "7.0.10" },
           { image: "valkey/valkey", version: "8" },
           { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "v1.27.0" },
           { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "latest" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         ruby: ["ruby-3.2", "ruby-3.3", "ruby-3.4"]
         database: [
-          { image: "redis", version: "7.0.10" },
+          { image: "redis", version: "7.0.15" },
           { image: "valkey/valkey", version: "8" },
           { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "v1.27.0" },
           { image: "docker.dragonflydb.io/dragonflydb/dragonfly", version: "latest" }


### PR DESCRIPTION
This PR follows 03c654ebe2538cca526d121478106ab89f783a04, where Sidekiq
lowered the Redis dependency requirement from 7.2 to 7.0, this time
ensuring that CI follows suit.