### PR TITLE
Added :exit event that will be triggered after all workers exited during shutdown

### DIFF
--- a/lib/sidekiq/config.rb
+++ b/lib/sidekiq/config.rb
@@ -27,6 +27,7 @@ module Sidekiq
         startup: [],
         quiet: [],
         shutdown: [],
+        exit: [],
         # triggers when we fire the first heartbeat on startup OR repairing a network partition
         heartbeat: [],
         # triggers on EVERY heartbeat call, every 10 seconds
@@ -258,7 +259,7 @@ module Sidekiq
     end
 
     # Register a block to run at a point in the Sidekiq lifecycle.
-    # :startup, :quiet or :shutdown are valid events.
+    # :startup, :quiet, :shutdown, or :exit are valid events.
     #
     #   Sidekiq.configure_server do |config|
     #     config.on(:shutdown) do

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -68,6 +68,7 @@ module Sidekiq
       stoppers.each(&:join)
 
       clear_heartbeat
+      fire_event(:exit, reverse: true)
     end
 
     def stopping?

--- a/myapp/config/initializers/sidekiq.rb
+++ b/myapp/config/initializers/sidekiq.rb
@@ -15,6 +15,7 @@ Sidekiq.configure_server do |config|
     # RubyProf::CallTreePrinter.new(result).print(f, :min_percent => 1)
     # end
   end
+  config.on(:exit) {}
 end
 
 class EmptyJob


### PR DESCRIPTION
This pull request proposes to introduce another hook called `:exit`, that will be triggered in the end of the shutdown cycle, and allow users to perform final cleanup, such as flushing and closing Karafka producers. It essentially works similarly to `at_exit` Ruby hook, but wrapped in a more idiomatic (from Sidekiq perspective) way of defining hooks.

```ruby
# config/initializers/sidekiq.rb

Sidekiq.configure_server do |config|
  config.on(:exit) do
    ::Karafka.producer.close
  end
end
```

### Background

When producing Karafka events from Sidekiq, we occasionally receive `WaterDrop::Errors::ProducerClosedError`. We tracked down the issue to [this recommendation from Karafka docs](https://karafka.io/docs/Producing-Messages/#closing-producer-used-in-sidekiq):

```ruby
# config/initializers/sidekiq.rb

Sidekiq.configure_server do |config|
  config.on(:shutdown) do
    ::Karafka.producer.close
  end
end
```

The problem occurs because the `:shutdown` hook is called right when `TERM` signal is received, but Sidekiq process is still waiting for long running jobs to finish.

Current recommendation from Mike is [to use `at_exit`](https://github.com/sidekiq/sidekiq/issues/5921) to run such clean up jobs.

Unfortunately, `at_exit` hooks might happen later in the application lifecycle, and it has been known to crash in the Waterdrop cleanup. Currently Karafka project [recommends to avoid `at_exit`](https://karafka.io/docs/FAQ/#can-at_exit-be-used-to-close-the-waterdrop-producer).

### Pros and Cons

Pros:

* Follows Sidekiq lifecycle configuration (code consistency)
* Does not rely on Ruby application lifecycle process, and calls the hook at a predictable time

Cons:

* As with `at_exit`, is not guaranteed to be called. For example, is Sidekiq timeout is the same or larger than process manager timeout, the process might get terminated before the job finishes
* Introduces another hook that looks similar to Ruby's native mechanism

### Naming

I have considered `shutdown_complete`, which sounds a bit wordy compared to other Sidekiq hooks. A short and expressive word `exit` looks reasonable enough.

