### PR TITLE
Remove null values from metrics charts to prevent chart shifting

### DIFF
--- a/lib/sidekiq/metrics/query.rb
+++ b/lib/sidekiq/metrics/query.rb
@@ -101,9 +101,9 @@ module Sidekiq
         time = @time
         @pool.with do |conn|
           redis_results.each do |(ms, p, f)|
-            result.job_results[klass].add_metric "ms", time, ms.to_i if ms
-            result.job_results[klass].add_metric "p", time, p.to_i if p
-            result.job_results[klass].add_metric "f", time, f.to_i if f
+            result.job_results[klass].add_metric "ms", time, ms.to_i
+            result.job_results[klass].add_metric "p", time, p.to_i
+            result.job_results[klass].add_metric "f", time, f.to_i
             result.job_results[klass].add_hist time, Histogram.new(klass).fetch(conn, time).reverse if minutes
             time -= stride
           end

--- a/web/views/metrics_for_job.erb
+++ b/web/views/metrics_for_job.erb
@@ -5,7 +5,10 @@
 
 <%
   job_result = @query_result.job_results[@name]
-  hist_totals = job_result.hist.values.first.zip(*job_result.hist.values[1..-1]).map(&:sum).reverse
+
+  raw_hist_values = job_result.hist.values.reject(&:nil?).reject(&:empty?)
+  hist_totals = raw_hist_values.first.zip(*raw_hist_values[1..-1]).map { |vals| vals.compact.sum }.reverse
+
   bucket_labels = Sidekiq::Metrics::Histogram::LABELS
   bucket_intervals = Sidekiq::Metrics::Histogram::BUCKET_INTERVALS
 %>

--- a/web/views/metrics_for_job.erb
+++ b/web/views/metrics_for_job.erb
@@ -5,10 +5,7 @@
 
 <%
   job_result = @query_result.job_results[@name]
-
-  raw_hist_values = job_result.hist.values.reject(&:nil?).reject(&:empty?)
-  hist_totals = raw_hist_values.first.zip(*raw_hist_values[1..-1]).map { |vals| vals.compact.sum }.reverse
-
+  hist_totals = job_result.hist.values.first.zip(*job_result.hist.values[1..-1]).map(&:sum).reverse
   bucket_labels = Sidekiq::Metrics::Histogram::LABELS
   bucket_intervals = Sidekiq::Metrics::Histogram::BUCKET_INTERVALS
 %>


### PR DESCRIPTION
### Issue Summary
Real-time Sidekiq metrics charts currently experience shifting issues over time due to null or empty data points being passed from the server-side to the frontend. This causes the starting point of line charts to shift leftward, negatively impacting readability and user experience.

**Update:** After receiving feedback, I've updated the approach to address this issue at the API level, not the view level. The metrics query API now explicitly returns `0` instead of `nil`.

### Proposed Changes
Updated the metrics query API (`lib/sidekiq/metrics/query.rb`) to replace `nil` values with explicit zeros (`0`) when no data is available.

### Implementation Details

```ruby
# lib/sidekiq/metrics/query.rb
redis_results.each do |(ms, p, f)|
  result.job_results[klass].add_metric "ms", time, ms.to_i
  result.job_results[klass].add_metric "p", time, p.to_i
  result.job_results[klass].add_metric "f", time, f.to_i
  # nil values are now explicitly converted to 0 by using `to_i`
end
```

### Expected Results
- Prevent chart shifting issues over time.
- Provide consistent and accurate real-time chart visualization.

### Testing
Manually verified on local environment that charts no longer shift upon prolonged monitoring.

### Additional Notes
This change addresses the root cause, ensuring API data integrity and simplifying front-end logic.