### PR TITLE
fix: Redis version requirement in embedded mode

### DIFF
--- a/lib/sidekiq/embedded.rb
+++ b/lib/sidekiq/embedded.rb
@@ -43,7 +43,7 @@ module Sidekiq
       # fire startup and start multithreading.
       info = config.redis_info
       ver = Gem::Version.new(info["redis_version"])
-      raise "You are connecting to Redis #{ver}, Sidekiq requires Redis 6.2.0 or greater" if ver < Gem::Version.new("6.2.0")
+      raise "You are connected to Redis #{ver}, Sidekiq requires Redis 7.0.0 or greater" if ver < Gem::Version.new("7.0.0")
 
       maxmemory_policy = info["maxmemory_policy"]
       if maxmemory_policy != "noeviction"


### PR DESCRIPTION
This PR fixes Redis version requirement in embedded mode.

https://github.com/sidekiq/sidekiq/blob/68b5462fb0a0a1a0299acb2edc0c7cff11e60f71/README.md?plain=1#L13-L16

https://github.com/sidekiq/sidekiq/blob/68b5462fb0a0a1a0299acb2edc0c7cff11e60f71/lib/sidekiq/cli.rb#L79