### PR TITLE
Remove obsolete "mike" params in `retries` action

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -240,8 +240,6 @@ module Sidekiq
       end
 
       post "/retries" do
-        route_params("mike")
-        url_params(:mike)
         redirect(request.path) unless url_params("key")
 
         url_params("key").each do |key|


### PR DESCRIPTION
Seems like they are debugging leftovers giving as this warning:

```
WARN  2025-03-21T13:27:39.832Z pid=201290 tid=2fga: Route parameter `mike` should be accessed via Symbol, not String
(at ruby/3.3.7/lib/ruby/gems/3.3.0/gems/sidekiq-8.0.1/lib/sidekiq/web/application.rb:243:in `block in <class:Application>')
```