### PR TITLE
Conditionally load ActiveJob and Rails integrations

### DIFF
--- a/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+module Sidekiq
+  module ActiveJob
+    # @api private
+    class Wrapper
+      include Sidekiq::Job
+
+      def perform(job_data)
+        ::ActiveJob::Base.execute(job_data.merge("provider_job_id" => jid))
+      end
+    end
+  end
+end
+
 module ActiveJob
   module QueueAdapters
     # Explicitly remove the implementation existing in older Rails.

--- a/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -1,88 +1,111 @@
 # frozen_string_literal: true
 
-module Sidekiq
-  module ActiveJob
-    # @api private
-    class Wrapper
-      include Sidekiq::Job
+begin
+  gem "activejob", ">= 7.0"
+  require "active_job"
 
-      def perform(job_data)
-        ::ActiveJob::Base.execute(job_data.merge("provider_job_id" => jid))
+  module Sidekiq
+    module ActiveJob
+      # @api private
+      class Wrapper
+        include Sidekiq::Job
+
+        def perform(job_data)
+          ::ActiveJob::Base.execute(job_data.merge("provider_job_id" => jid))
+        end
       end
     end
   end
-end
 
-module ActiveJob
-  module QueueAdapters
-    # Explicitly remove the implementation existing in older Rails.
-    remove_const(:SidekiqAdapter) if const_defined?(:SidekiqAdapter)
-
-    # Sidekiq adapter for Active Job
+  unless ActiveJob::Base.respond_to?(:sidekiq_options)
+    # By including the Options module, we allow AJs to directly control sidekiq features
+    # via the *sidekiq_options* class method and, for instance, not use AJ's retry system.
+    # AJ retries don't show up in the Sidekiq UI Retries tab, don't save any error data, can't be
+    # manually retried, don't automatically die, etc.
     #
-    # To use Sidekiq set the queue_adapter config to +:sidekiq+.
-    #
-    #   Rails.application.config.active_job.queue_adapter = :sidekiq
-    class SidekiqAdapter
-      # Defines whether enqueuing should happen implicitly to after commit when called
-      # from inside a transaction.
-      # @api private
-      def enqueue_after_transaction_commit?
-        true
-      end
+    #   class SomeJob < ActiveJob::Base
+    #     queue_as :default
+    #     sidekiq_options retry: 3, backtrace: 10
+    #     def perform
+    #     end
+    #   end
+    ActiveJob::Base.include Sidekiq::Job::Options
+  end
 
-      # @api private
-      def enqueue(job)
-        job.provider_job_id = Sidekiq::ActiveJob::Wrapper.set(
-          wrapped: job.class,
-          queue: job.queue_name
-        ).perform_async(job.serialize)
-      end
+  # Patch the ActiveJob module
+  module ActiveJob
+    module QueueAdapters
+      # Explicitly remove the implementation existing in older Rails.
+      remove_const(:SidekiqAdapter) if const_defined?(:SidekiqAdapter)
 
-      # @api private
-      def enqueue_at(job, timestamp)
-        job.provider_job_id = Sidekiq::ActiveJob::Wrapper.set(
-          wrapped: job.class,
-          queue: job.queue_name
-        ).perform_at(timestamp, job.serialize)
-      end
+      # Sidekiq adapter for Active Job
+      #
+      # To use Sidekiq set the queue_adapter config to +:sidekiq+.
+      #
+      #   Rails.application.config.active_job.queue_adapter = :sidekiq
+      class SidekiqAdapter
+        # Defines whether enqueuing should happen implicitly to after commit when called
+        # from inside a transaction.
+        # @api private
+        def enqueue_after_transaction_commit?
+          true
+        end
 
-      # @api private
-      def enqueue_all(jobs)
-        enqueued_count = 0
-        jobs.group_by(&:class).each do |job_class, same_class_jobs|
-          same_class_jobs.group_by(&:queue_name).each do |queue, same_class_and_queue_jobs|
-            immediate_jobs, scheduled_jobs = same_class_and_queue_jobs.partition { |job| job.scheduled_at.nil? }
+        # @api private
+        def enqueue(job)
+          job.provider_job_id = Sidekiq::ActiveJob::Wrapper.set(
+            wrapped: job.class,
+            queue: job.queue_name
+          ).perform_async(job.serialize)
+        end
 
-            if immediate_jobs.any?
-              jids = Sidekiq::Client.push_bulk(
-                "class" => Sidekiq::ActiveJob::Wrapper,
-                "wrapped" => job_class,
-                "queue" => queue,
-                "args" => immediate_jobs.map { |job| [job.serialize] }
-              )
-              enqueued_count += jids.compact.size
-            end
+        # @api private
+        def enqueue_at(job, timestamp)
+          job.provider_job_id = Sidekiq::ActiveJob::Wrapper.set(
+            wrapped: job.class,
+            queue: job.queue_name
+          ).perform_at(timestamp, job.serialize)
+        end
 
-            if scheduled_jobs.any?
-              jids = Sidekiq::Client.push_bulk(
-                "class" => Sidekiq::ActiveJob::Wrapper,
-                "wrapped" => job_class,
-                "queue" => queue,
-                "args" => scheduled_jobs.map { |job| [job.serialize] },
-                "at" => scheduled_jobs.map { |job| job.scheduled_at&.to_f }
-              )
-              enqueued_count += jids.compact.size
+        # @api private
+        def enqueue_all(jobs)
+          enqueued_count = 0
+          jobs.group_by(&:class).each do |job_class, same_class_jobs|
+            same_class_jobs.group_by(&:queue_name).each do |queue, same_class_and_queue_jobs|
+              immediate_jobs, scheduled_jobs = same_class_and_queue_jobs.partition { |job| job.scheduled_at.nil? }
+
+              if immediate_jobs.any?
+                jids = Sidekiq::Client.push_bulk(
+                  "class" => Sidekiq::ActiveJob::Wrapper,
+                  "wrapped" => job_class,
+                  "queue" => queue,
+                  "args" => immediate_jobs.map { |job| [job.serialize] }
+                )
+                enqueued_count += jids.compact.size
+              end
+
+              if scheduled_jobs.any?
+                jids = Sidekiq::Client.push_bulk(
+                  "class" => Sidekiq::ActiveJob::Wrapper,
+                  "wrapped" => job_class,
+                  "queue" => queue,
+                  "args" => scheduled_jobs.map { |job| [job.serialize] },
+                  "at" => scheduled_jobs.map { |job| job.scheduled_at&.to_f }
+                )
+                enqueued_count += jids.compact.size
+              end
             end
           end
+          enqueued_count
         end
-        enqueued_count
-      end
 
-      # Defines a class alias for backwards compatibility with enqueued Active Job jobs.
-      # @api private
-      class JobWrapper < Sidekiq::ActiveJob::Wrapper
+        # Defines a class alias for backwards compatibility with enqueued Active Job jobs.
+        # @api private
+        class JobWrapper < Sidekiq::ActiveJob::Wrapper
+        end
       end
     end
   end
+rescue Gem::LoadError
+  # ActiveJob not available or version requirement not met
 end

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -146,4 +146,4 @@ module Sidekiq
   class Shutdown < Interrupt; end
 end
 
-require "sidekiq/rails" if defined?(::Rails::Engine)
+require "sidekiq/rails"

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -1,42 +1,9 @@
 # frozen_string_literal: true
 
 require "sidekiq/job"
-require "rails"
 
 module Sidekiq
-  module ActiveJob
-    # @api private
-    class Wrapper
-      include Sidekiq::Job
-
-      def perform(job_data)
-        ::ActiveJob::Base.execute(job_data.merge("provider_job_id" => jid))
-      end
-    end
-  end
-
-  class Rails < ::Rails::Engine
-    class Reloader
-      def initialize(app = ::Rails.application)
-        @app = app
-      end
-
-      def call
-        params = (::Rails::VERSION::STRING >= "7.1") ? {source: "job.sidekiq"} : {}
-        @app.reloader.wrap(**params) do
-          yield
-        end
-      end
-
-      def inspect
-        "#<Sidekiq::Rails::Reloader @app=#{@app.class.name}>"
-      end
-
-      def to_hash
-        {app: @app.class.name}
-      end
-    end
-
+  if defined?(::ActiveJob)
     # By including the Options module, we allow AJs to directly control sidekiq features
     # via the *sidekiq_options* class method and, for instance, not use AJ's retry system.
     # AJ retries don't show up in the Sidekiq UI Retries tab, don't save any error data, can't be
@@ -48,34 +15,65 @@ module Sidekiq
     #     def perform
     #     end
     #   end
-    initializer "sidekiq.active_job_integration" do
-      ActiveSupport.on_load(:active_job) do
-        require_relative "../active_job/queue_adapters/sidekiq_adapter"
-        include ::Sidekiq::Job::Options unless respond_to?(:sidekiq_options)
+    require_relative "../active_job/queue_adapters/sidekiq_adapter"
+    ::ActiveJob::Base.include ::Sidekiq::Job::Options unless ::ActiveJob::Base.respond_to?(:sidekiq_options)
+    module ActiveJob
+      # @api private
+      class Wrapper
+        include Sidekiq::Job
+
+        def perform(job_data)
+          ::ActiveJob::Base.execute(job_data.merge("provider_job_id" => jid))
+        end
       end
     end
+  end
 
-    initializer "sidekiq.backtrace_cleaner" do
-      Sidekiq.configure_server do |config|
-        config[:backtrace_cleaner] = ->(backtrace) { ::Rails.backtrace_cleaner.clean(backtrace) }
+  if defined?(::Rails::Engine)
+    class Rails < ::Rails::Engine
+      class Reloader
+        def initialize(app = ::Rails.application)
+          @app = app
+        end
+
+        def call
+          params = (::Rails::VERSION::STRING >= "7.1") ? { source: "job.sidekiq" } : {}
+          @app.reloader.wrap(**params) do
+            yield
+          end
+        end
+
+        def inspect
+          "#<Sidekiq::Rails::Reloader @app=#{@app.class.name}>"
+        end
+
+        def to_hash
+          { app: @app.class.name }
+        end
       end
-    end
 
-    # This hook happens after all initializers are run, just before returning
-    # from config/environment.rb back to sidekiq/cli.rb.
-    #
-    # None of this matters on the client-side, only within the Sidekiq process itself.
-    config.after_initialize do
-      Sidekiq.configure_server do |config|
-        config[:reloader] = Sidekiq::Rails::Reloader.new
+      initializer "sidekiq.backtrace_cleaner" do
+        Sidekiq.configure_server do |config|
+          config[:backtrace_cleaner] = ->(backtrace) { ::Rails.backtrace_cleaner.clean(backtrace) }
+        end
+      end
 
-        # This is the integration code necessary so that if a job uses `Rails.logger.info "Hello"`,
-        # it will appear in the Sidekiq console with all of the job context.
-        unless ::Rails.logger == config.logger || ::ActiveSupport::Logger.logger_outputs_to?(::Rails.logger, $stdout)
-          if ::Rails.logger.respond_to?(:broadcast_to)
-            ::Rails.logger.broadcast_to(config.logger)
-          else
-            ::Rails.logger.extend(::ActiveSupport::Logger.broadcast(config.logger))
+      # This hook happens after all initializers are run, just before returning
+      # from config/environment.rb back to sidekiq/cli.rb.
+      #
+      # None of this matters on the client-side, only within the Sidekiq process itself.
+      config.after_initialize do
+        Sidekiq.configure_server do |config|
+          config[:reloader] = Sidekiq::Rails::Reloader.new
+
+          # This is the integration code necessary so that if a job uses `Rails.logger.info "Hello"`,
+          # it will appear in the Sidekiq console with all of the job context.
+          unless ::Rails.logger == config.logger || ::ActiveSupport::Logger.logger_outputs_to?(::Rails.logger, $stdout)
+            if ::Rails.logger.respond_to?(:broadcast_to)
+              ::Rails.logger.broadcast_to(config.logger)
+            else
+              ::Rails.logger.extend(::ActiveSupport::Logger.broadcast(config.logger))
+            end
           end
         end
       end

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -17,16 +17,6 @@ module Sidekiq
     #   end
     require_relative "../active_job/queue_adapters/sidekiq_adapter"
     ::ActiveJob::Base.include ::Sidekiq::Job::Options unless ::ActiveJob::Base.respond_to?(:sidekiq_options)
-    module ActiveJob
-      # @api private
-      class Wrapper
-        include Sidekiq::Job
-
-        def perform(job_data)
-          ::ActiveJob::Base.execute(job_data.merge("provider_job_id" => jid))
-        end
-      end
-    end
   end
 
   if defined?(::Rails::Engine)


### PR DESCRIPTION
Remove the assumption that Rails will be installed from the meta gem or granular with ActiveJob.

- A script could be using ActiveJob in standalone and won't need Rails initialization
- A Rails application could have Sidekiq and not use the ActiveJob wrapper to reduce dependencies

This change wraps relevant code in `if defined?` checks to ensure Sidekiq only loads what's needed based on the actual environment dependencies.

Fixes #6668 