### PR TITLE
[Web]: Allow loading of fonts from data URLs

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -15,7 +15,7 @@ module Sidekiq
         "default-src 'self' https: http:",
         "child-src 'self'",
         "connect-src 'self' https: http: wss: ws:",
-        "font-src 'none'",
+        "font-src 'self' data:",
         "frame-src 'self'",
         "img-src 'self' https: http: data:",
         "manifest-src 'self'",


### PR DESCRIPTION
Update CSP (content security policy) so it allows fonts to load from `data:` style URLs. This was tested on sidekiq 8.0.2.

Before:

![Screenshot 2025-04-22 at 16 54 02](https://github.com/user-attachments/assets/7274832e-2f72-4449-bc3a-57c84da79aab)

After:
![Screenshot 2025-04-22 at 16 54 31](https://github.com/user-attachments/assets/4aa017f6-88ed-42bf-bb90-e00144bf2d3d)
