### PR TITLE
Don't swallow NoMethodErrors in jobs setting current_attributes

### DIFF
--- a/lib/sidekiq/middleware/current_attributes.rb
+++ b/lib/sidekiq/middleware/current_attributes.rb
@@ -71,11 +71,14 @@ module Sidekiq
         retried = false
 
         begin
+          set_succeeded = false
           klass.set(attrs) do
+            set_succeeded = true
             wrap(klass_attrs, &block)
           end
-        rescue NoMethodError
-          raise if retried
+        rescue NoMethodError => e
+          # Don't retry if the no method error didn't come from current attributes
+          raise if retried || set_succeeded
 
           # It is possible that the `CurrentAttributes` definition
           # was changed before the job started processing.

--- a/test/current_attributes_test.rb
+++ b/test/current_attributes_test.rb
@@ -124,6 +124,23 @@ describe "Current attributes" do
     end
   end
 
+  it "doesn't swallow errors raised in the job" do
+    cm = Sidekiq::CurrentAttributes::Load.new({
+      "cattr" => "Myapp::Current"
+    })
+
+    job = {"cattr" => {"user_id" => 123}}
+    assert_raises do
+      first_time = true
+      cm.call(nil, job, nil) do
+        if first_time
+          first_time = false
+          raise nil.this_method_is_undefined
+        end
+      end
+    end
+  end
+
   private
 
   def with_context(strklass, attr, value)


### PR DESCRIPTION
~Instead of waiting for an error and then filtering out any current attributes, only attempt to set the ones that currently exist.~

If we have successfully set the current attributes, we don't retry if we catch an error.

The `NoMethodError` that was being rescued from also applied to the job that was being wrapped. This caused errors to be silently hidden and the job retried without going into the retry queue, or alerting any bug tracking tools that have been set up.

This recently bit us in a worker calling a third party API because of a bug in our code after the response was received. A NoMethodError was raised, and we retried the API call without being alerted to the failure. The API responded differently the second time (because we'd already made that request), and the second time the code ran we hit the failure branch, which also didn't raise an error as our code assumed it was a legitimate failure.

Ofcourse, ideally our job would have been idempotent, so the retry wouldn't have mattered. But if we were writing perfect code we wouldn't have hit the NoMethodError in the first place.

I saw some discussion on the original PR for this where the rescue was preferred https://github.com/sidekiq/sidekiq/pull/6343 but NoMethodError seems too generic for a blanket rescue. This approach seems cleaner to me, but if the performance of the select is a concern we could try inspecting the error to ensure it was a result of CurrentAttributes instead?