### PR TITLE
Reduce minimum rack version.

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "redis-client", ">= 0.23.2"
   gem.add_dependency "connection_pool", ">= 2.5.0"
-  gem.add_dependency "rack", ">= 3.1.0"
+  gem.add_dependency "rack", ">= 2.0.0"
   gem.add_dependency "json", ">= 2.9.0"
   gem.add_dependency "logger", ">= 1.6.2"
 end


### PR DESCRIPTION
Hello,

Wanted to check in about the rack minimum version change. Feedbin uses unicorn and unicorn requires `rack < 3` so I've got a gem conflict there.

I tried this out locally and all tests passed the the web UI loaded fine, but I'm not sure if there were other reasons for the change. Happy to try to address them if so.

Thanks!

<img width="1504" alt="Screenshot 2025-05-01 at 5 06 38 PM" src="https://github.com/user-attachments/assets/b8e5ca9a-b92b-4df5-9fc3-8b26af08f4e4" />
