### PR TITLE
Only require what is necessary from `cgi` for Ruby 3.5

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -2,7 +2,7 @@
 
 require "uri"
 require "yaml"
-require "cgi"
+require "cgi/escape"
 
 module Sidekiq
   # These methods are available to pages within the Web UI and UI extensions.


### PR DESCRIPTION
In Ruby 3.5, most of the `cgi` gem is removed. Only methods relating to escaping/unescaping are retained.

Those are the only thing that's being used, so use the more specific require and avoid the warning that would otherwise be emitted. Doing it like this works since Ruby 2.4.

https://bugs.ruby-lang.org/issues/21258