### PR TITLE
Don't load ActiveJob::Base during initialization

### DIFF
--- a/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -17,7 +17,7 @@ begin
     end
   end
 
-  unless ActiveJob::Base.respond_to?(:sidekiq_options)
+  ActiveSupport.on_load(:active_job) do
     # By including the Options module, we allow AJs to directly control sidekiq features
     # via the *sidekiq_options* class method and, for instance, not use AJ's retry system.
     # AJ retries don't show up in the Sidekiq UI Retries tab, don't save any error data, can't be
@@ -29,7 +29,7 @@ begin
     #     def perform
     #     end
     #   end
-    ActiveJob::Base.include Sidekiq::Job::Options
+    include Sidekiq::Job::Options unless respond_to?(:sidekiq_options)
   end
 
   # Patch the ActiveJob module

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
-require "sidekiq/job"
-require_relative "../active_job/queue_adapters/sidekiq_adapter"
-
 module Sidekiq
   begin
     gem "railties", ">= 7.0"
     require "rails"
+    require "sidekiq/job"
+    require_relative "../active_job/queue_adapters/sidekiq_adapter"
 
     class Rails < ::Rails::Engine
       class Reloader

--- a/test/dummy/bin/rails
+++ b/test/dummy/bin/rails
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -8,6 +8,7 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
 require "rails/test_unit/railtie"
+require "sidekiq"
 
 module Dummy
   class Application < Rails::Application
@@ -16,8 +17,5 @@ module Dummy
     config.load_defaults "7.0"
     config.active_job.queue_adapter = :sidekiq
     config.active_support.to_time_preserves_timezone = :zone # 8.0 deprecation
-
-    # Do not print logs when running tests.
-    Sidekiq.logger.level = :fatal
   end
 end

--- a/test/dummy/config/boot.rb
+++ b/test/dummy/config/boot.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile", __dir__)
+require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/test/dummy/config/initializers/active_job.rb
+++ b/test/dummy/config/initializers/active_job.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Rails.application.config.active_job.logger = Logger.new(STDOUT)

--- a/test/dummy/config/initializers/sidekiq.rb
+++ b/test/dummy/config/initializers/sidekiq.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Do not print logs when running tests.
+Sidekiq.logger.level = :fatal

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -47,4 +47,14 @@ describe "ActiveJob" do
     # AJ's queue_as should take precedence over Sidekiq's queue option
     assert_equal "bar", job["queue"]
   end
+
+  it "doesn't load ActiveJob::Base before Rails initialization is complete" do
+    # Rails sets ActiveJob::Base to an ActiveSupport::Logger by default,
+    # but we override config.active_job.logger in dummy/config/initializers/active_job.rb to a regular ::Logger.
+    # Check that that config has taken effect - if not, it implies that ActiveJob::Base got loaded
+    # before our initializer is complete.
+    app_dir = File.expand_path("./dummy", __dir__)
+    logger_class = IO.popen(["bin/rails", "runner", "puts ActiveJob::Base.logger.class"], chdir: app_dir).read.chomp
+    assert_equal "Logger", logger_class
+  end
 end


### PR DESCRIPTION
This is an extension of @seuros's PR #6689

Referencing ActiveJob::Base during the Rails initialization process can cause it to load too soon, which results in app-level config (eg `config.active_job.logger`) being ignored.  (These settings are only copied onto ActiveJob::Base once, the first time it loads at https://github.com/rails/rails/blob/fcf01b8820b6e4c3bd70ae3cc653229bbe5a1fba/activejob/lib/active_job/railtie.rb#L80-L82).
This broke in Sidekiq 8.0.3 due to https://github.com/sidekiq/sidekiq/pull/6669.

I've tried to demonstrate that in a new test case here - https://github.com/jdelStrother/sidekiq/blob/16c2f8589e3022fdc081ebd0196ad4a8b31e4774/test/rails_test.rb#L51-L59 - which passes on 8.0.2 and fails on 8.0.3. The test case itself is kind of hacky, open to better suggestions.

I think we can fix it by replacing references to `ActiveJob::Base` in active_job/sidekiq_adapter.rb with `ActiveSupport.on_load(:active_job) { ... }`, but would be good to get confirmation from @seuros that this still works ok with their ActiveJob-without-Rails use case.