### PR TITLE
fix: We should load rails if rails engine is defined for rspec

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -146,4 +146,4 @@ module Sidekiq
   class Shutdown < Interrupt; end
 end
 
-require "sidekiq/rails"
+require "sidekiq/rails" if defined?(::Rails::Engine)


### PR DESCRIPTION
We had an issue in our test suite where `RAILS_ENV=test` seems not to be set with `bundle exec rspec ...`.
`RAILS_ENV=test bundle exec rspec ...` fixed the problem, it should not be required

We tracked the issue to be from sidekiq 8.0.3.

It seems that getting back the following line solved the issue:
`require "sidekiq/rails" if defined?(::Rails::Engine)`

(instead of `require "sidekiq/rails"`)

https://github.com/sidekiq/sidekiq/compare/3765cfd67b0dc5d1b8d6d85739c6e2cdd0aa2f2a...205df02327a2402f4c844df07324d8ac3da80ffb 

Maybe related to https://github.com/sidekiq/sidekiq/issues/6683