### PR TITLE
Make SidekiqAdapter subclass AbstractAdapter

### DIFF
--- a/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -43,7 +43,7 @@ begin
       # To use Sidekiq set the queue_adapter config to +:sidekiq+.
       #
       #   Rails.application.config.active_job.queue_adapter = :sidekiq
-      class SidekiqAdapter
+      class SidekiqAdapter < AbstractAdapter
         # Defines whether enqueuing should happen implicitly to after commit when called
         # from inside a transaction.
         # @api private


### PR DESCRIPTION
https://github.com/rails/rails/pull/55127 adds a new `stopping?` method to the `AbstractAdapter`.

`SidekiqAdapter` should implement that at some point, but for now by subclassing `AbstractAdapter` we ensure that it falls back to the default implementation.