### PR TITLE
Load CurrentAttributes inside client

### DIFF
--- a/lib/sidekiq/middleware/current_attributes.rb
+++ b/lib/sidekiq/middleware/current_attributes.rb
@@ -50,7 +50,7 @@ module Sidekiq
         @cattrs = cattrs
       end
 
-      def call(_, job, _, &block)
+      def call(_, job, *, &block)
         klass_attrs = {}
 
         @cattrs.each do |(key, strklass)|
@@ -93,6 +93,7 @@ module Sidekiq
       def persist(klass_or_array, config = Sidekiq.default_configuration)
         cattrs = build_cattrs_hash(klass_or_array)
 
+        config.client_middleware.prepend Load, cattrs
         config.client_middleware.add Save, cattrs
         config.server_middleware.prepend Load, cattrs
       end


### PR DESCRIPTION
We use CurrentAttributes (with the related sidekiq middleware enabled) and rails sharding.

We have a custom client middleware that does some logic depending on the shard value in our `Current` instance. All is good and works correctly until the job is failed and enqueued for a retry. Because when sidekiq's scheduler retrieves the job from the retry queue (to push it to a regular queue), it runs the client middleware again before pushing. https://github.com/sidekiq/sidekiq/blob/d70ef9bf1e5b7b9d39838b2a9b9acc5f468a5ec5/lib/sidekiq/scheduled.rb#L39
The job has a `Current` stored from the first try, but it is not restored when pushing by the scheduler, so the logic in our custom client middleware is incorrect now.  