### PR TITLE
Add and expose capsule data in Sidekiq::Process, see #6295

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 HEAD
 ----------
 
+- Updated `Sidekiq::Process` API to provide capsule data. The `queues` and `weights` data will be removed from Redis in Sidekiq 8.1, as this data can now be found in the `capsules` element. [#6295]
 - Job iteration now exposes `current_object` for easy access within the `around_iteration` callback [#6774]
 - Fix JS race condition which could skip confirmation dialogs when Live Polling [#6768]
 - Fix edge case which could lose CurrentAttributes [#6767]

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -1059,9 +1059,9 @@ module Sidekiq
   #   'started_at' => <process start time>,
   #   'pid' => 12345,
   #   'tag' => 'myapp'
-  #   'concurrency' => 25,
-  #   'queues' => ['default', 'low'],
-  #   'busy' => 10,
+  #   'concurrency' => 5,
+  #   'capsules' => {"default" => {"mode" => "weighted", "concurrency" => 5, "weights" => {"default" => 2, "low" => 1}}},
+  #   'busy' => 3,
   #   'beat' => <last heartbeat>,
   #   'identity' => <unique string identifying the process>,
   #   'embedded' => true,
@@ -1089,12 +1089,25 @@ module Sidekiq
       self["identity"]
     end
 
+    # deprecated, use capsules below
     def queues
-      self["queues"]
+      capsules.values.flat_map { |x| x["weights"].keys }.uniq
     end
 
+    # deprecated, use capsules below
     def weights
-      self["weights"]
+      hash = {}
+      capsules.values.each do |cap|
+        # Note: will lose data if two capsules are processing the same named queue
+        cap["weights"].each_pair do |queue, weight|
+          hash[queue] = weight
+        end
+      end
+      hash
+    end
+
+    def capsules
+      self["capsules"]
     end
 
     def version

--- a/lib/sidekiq/capsule.rb
+++ b/lib/sidekiq/capsule.rb
@@ -38,6 +38,10 @@ module Sidekiq
       @mode = :strict
     end
 
+    def to_h
+      {concurrency: concurrency, mode: mode, weights: weights}
+    end
+
     def fetcher
       @fetcher ||= begin
         instance = (config[:fetch_class] || Sidekiq::BasicFetch).new(self)

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -252,17 +252,20 @@ module Sidekiq
         "pid" => ::Process.pid,
         "tag" => @config[:tag] || "",
         "concurrency" => @config.total_concurrency,
+        "capsules" => @config.capsules.each_with_object({}) { |(name, cap), memo|
+          memo[name] = cap.to_h
+        },
+        #####
+        # TODO deprecated, remove in 8.1
+        # This data is now found in the `capsules` element above
         "queues" => @config.capsules.values.flat_map { |cap| cap.queues }.uniq,
-        "weights" => to_weights,
+        "weights" => @config.capsules.values.map(&:weights),
+        #####
         "labels" => @config[:labels].to_a,
         "identity" => identity,
         "version" => Sidekiq::VERSION,
         "embedded" => @embedded
       }
-    end
-
-    def to_weights
-      @config.capsules.values.map(&:weights)
     end
 
     def to_json

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -545,8 +545,7 @@ describe "API" do
         "key" => identity_string,
         "identity" => identity_string,
         "started_at" => Time.now.to_f - 15,
-        "queues" => ["foo", "bar"],
-        "weights" => {"foo" => 1, "bar" => 1},
+        "capsules" => {"default" => {"mode" => "weighted", "concurrency" => 5, "weights" => {"foo" => 1, "bar" => 1}}},
         "version" => Sidekiq::VERSION,
         "embedded" => false
       }
@@ -585,8 +584,7 @@ describe "API" do
         "key" => identity_string,
         "identity" => identity_string,
         "started_at" => Time.now.to_f - 15,
-        "queues" => ["foo", "bar"],
-        "weights" => {"foo" => 1, "bar" => 1},
+        "capsules" => {"default" => {"mode" => "weighted", "concurrency" => 5, "weights" => {"foo" => 1, "bar" => 1}}},
         "version" => Sidekiq::VERSION,
         "embedded" => true
       }

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -89,7 +89,7 @@ describe Sidekiq::Web do
       @config.redis do |conn|
         conn.incr("busy")
         conn.sadd("processes", ["foo:1234"])
-        conn.hset("foo:1234", "info", Sidekiq.dump_json("hostname" => "foo", "started_at" => Time.now.to_f, "queues" => [], "concurrency" => 10), "at", Time.now.to_f, "busy", 4)
+        conn.hset("foo:1234", "info", Sidekiq.dump_json("hostname" => "foo", "started_at" => Time.now.to_f, "capsules" => {}, "concurrency" => 10), "at", Time.now.to_f, "busy", 4)
         identity = "foo:1234:work"
         hash = {queue: "critical", payload: Sidekiq.dump_json({"class" => WebJob.name, "args" => [1, "abc"], "tags" => %w[foobar_100 <eviltag/>]}), run_at: Time.now.to_i}
         conn.hset(identity, 1001, Sidekiq.dump_json(hash))
@@ -563,7 +563,7 @@ describe Sidekiq::Web do
     @config.redis do |conn|
       pro = "foo:1234"
       conn.sadd("processes", [pro])
-      conn.hset(pro, "info", Sidekiq.dump_json("started_at" => Time.now.to_f, "labels" => ["frumduz"], "queues" => [], "concurrency" => 10), "busy", 1, "beat", Time.now.to_f)
+      conn.hset(pro, "info", Sidekiq.dump_json("started_at" => Time.now.to_f, "labels" => ["frumduz"], "capsules" => {}, "concurrency" => 10), "busy", 1, "beat", Time.now.to_f)
       identity = "#{pro}:work"
       hash = {queue: "critical", payload: Sidekiq.dump_json({"class" => "FailJob", "args" => ["<a>hello</a>"]}), run_at: Time.now.to_i}
       conn.hset(identity, 100001, Sidekiq.dump_json(hash))


### PR DESCRIPTION
Deprecate `weights` and `queues` as those elements are now lossy.