### PR TITLE
Update uk.yml to be more polite

### DIFF
--- a/web/locales/uk.yml
+++ b/web/locales/uk.yml
@@ -14,8 +14,8 @@ uk:
   CreatedAt: Створено
   CurrentMessagesInQueue: Поточні задачі у черзі <span class='title'>%{queue}</span>
   Dashboard: Панель керування
-  Dead: Вбитих
-  DeadJobs: Вбиті задачі
+  Dead: Зупинених
+  DeadJobs: Зупинені задачі
   Delete: Видалити
   DeleteAll: Видалити усі
   Deploy: Деплой
@@ -33,8 +33,8 @@ uk:
   History: Історія
   Job: Задача
   Jobs: Задачі
-  Kill: Вбити
-  KillAll: Вбити все
+  Kill: Зупинити
+  KillAll: Зупинити все
   LastRetry: Остання спроба
   Latency: Затримка
   LivePoll: Постійне опитування
@@ -42,7 +42,7 @@ uk:
   Name: Назва
   Namespace: Простір імен
   NextRetry: Наступна спроба
-  NoDeadJobsFound: Вбитих задач не знайдено
+  NoDeadJobsFound: Зупинених задач не знайдено
   NoRetriesFound: Спроб не знайдено
   NoScheduledFound: Запланованих задач не знайдено
   NotYetEnqueued: Ще не в черзі


### PR DESCRIPTION
🔄 Replaced harsh terminology: Killed → Stopped
This pull request updates the Ukrainian translations related to job termination in the UI. Specifically, we’ve replaced the word "вбиті" (translated from "Killed") with "зупинені" ("Stopped") to make the interface more user-friendly and emotionally neutral.

✅ What was changed:
"Dead" → "Зупинені"

"DeadJobs" → "Зупинені задачі"

"NoDeadJobsFound" → "Зупинених задач не знайдено"

"Kill" → "Зупинити"

"KillAll" → "Зупинити все"

🧠 Rationale:
The word "вбиті" ("Killed") sounds unnecessarily violent or aggressive in Ukrainian, which can be jarring to users — especially non-technical audiences.

"Зупинені" ("Stopped") conveys the same technical meaning (a job that was terminated and won’t be retried), but in a more neutral, professional, and user-friendly way.

This aligns with modern UX writing practices, which recommend avoiding emotionally charged or violent language in user interfaces wherever possible.

📌 Note:
If the context absolutely requires emphasis on forced termination (e.g., for internal tools or logs), the term "Примусово зупинені" ("Force-stopped") may be considered instead. However, for general UI use, "Зупинені" remains the preferred choice.