### PR TITLE
Fixes "Logs are colorized regardless of colorized_logging setting"

### DIFF
--- a/lib/sidekiq/logger.rb
+++ b/lib/sidekiq/logger.rb
@@ -46,17 +46,25 @@ module Sidekiq
             end
           }.join(" ")}"
         end
+
+        def coloured_severity(severity)
+          if ::Rails.application.config.colorize_logging
+            Formatters::COLORS[severity]
+          else
+            severity
+          end
+        end
       end
 
       class Pretty < Base
         def call(severity, time, program_name, message)
-          "#{Formatters::COLORS[severity]} #{time.utc.iso8601(3)} pid=#{::Process.pid} tid=#{tid}#{format_context}: #{message}\n"
+          "#{coloured_severity(severity)} #{time.utc.iso8601(3)} pid=#{::Process.pid} tid=#{tid}#{format_context}: #{message}\n"
         end
       end
 
       class WithoutTimestamp < Pretty
         def call(severity, time, program_name, message)
-          "#{Formatters::COLORS[severity]} pid=#{::Process.pid} tid=#{tid} #{format_context}: #{message}\n"
+          "#{coloured_severity(severity)} pid=#{::Process.pid} tid=#{tid} #{format_context}: #{message}\n"
         end
       end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -132,6 +132,15 @@ describe "logger" do
     assert_predicate logger, :warn?
   end
 
+  it 'tests coloured severity' do
+    context 'when colorize_logging is true' do
+      assert_equal "\e[1;34mINFO \e[0m", @logger.formatter.coloured_severity('INFO')
+    end
+    context 'when colorize_logging is false' do
+      assert_equal 'INFO', @logger.formatter.coloured_severity('INFO')
+    end
+  end
+
   def reset(io)
     io.truncate(0)
     io.rewind


### PR DESCRIPTION
Sidekiq::Logger: colorize logs only is `::Rails.application.config.colorize_logging`.