### PR TITLE
Remove custom CSS ::selection color

### DIFF
--- a/web/assets/stylesheets/style.css
+++ b/web/assets/stylesheets/style.css
@@ -29,8 +29,6 @@
 
 *, *::before, *::after { box-sizing: border-box; }
 
-::selection { background: var(--color-selected); }
-
 :focus-visible {
   outline: 1px solid oklch(from var(--color-primary) l c h / 50%);
 }
@@ -567,7 +565,6 @@ body > footer .nav {
     --color-border: oklch(25% 0.01 256);
     --color-input-border: oklch(31% 0.01 256);
     --color-selected: oklch(27% 0.01 256);
-    --color-selected-text: oklch(55% 0.11 45);
     --color-table-bg-alt: oklch(24% 0.01 256);
     --color-shadow: oklch(9% 0.01 256 / 10%);
     --color-text: oklch(75% 0.01 256);
@@ -616,10 +613,6 @@ body > footer .nav {
   .label-info { background: var(--color-info); }
   .label-danger { background: var(--color-danger); }
   .label-warning { background: var(--color-warning); }
-
-  td.box::selection {
-    background-color: var(--color-selected-text);
-  }
 }
 
 @media (max-width: 800px) { :root { --font-size: 14px; } }


### PR DESCRIPTION
The selection color had too little contrast and overriding the browser default harms accessibility.

See https://developer.mozilla.org/en-US/docs/Web/CSS/::selection#accessibility:

> Don't override selected text styles for purely aesthetic reasons — users can customize them to suit their needs. For people experiencing cognitive concerns or who are less technologically literate, unexpected changes to selection styles may hurt their understanding of the functionality.

When selecting everything on the page (cmd+A), this is the result (last row in the table hovered):

### Before

<img width="1351" height="965" alt="selection_before_light" src="https://github.com/user-attachments/assets/e1d29808-8525-430b-94b2-b6674bb4e39e" />
<img width="1351" height="965" alt="selection_before_dark" src="https://github.com/user-attachments/assets/56996caf-2668-4854-86c0-5c165a63d4b7" />

### After

<img width="1351" height="965" alt="selection_after_light" src="https://github.com/user-attachments/assets/72113045-d490-4cf4-a530-705547267659" />
<img width="1351" height="965" alt="selection_after_dark" src="https://github.com/user-attachments/assets/7d8e5db1-cd37-4f43-bf1d-4404985935ed" />
