### PR TITLE
Support schedules for `perform_bulk`

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -131,7 +131,7 @@ module Sidekiq
     def push_bulk(items)
       batch_size = items.delete(:batch_size) || items.delete("batch_size") || 1_000
       args = items["args"]
-      at = items.delete("at")
+      at = items.delete("at") || items.delete(:at)
       raise ArgumentError, "Job 'at' must be a Numeric or an Array of Numeric timestamps" if at && (Array(at).empty? || !Array(at).all? { |entry| entry.is_a?(Numeric) })
       raise ArgumentError, "Job 'at' Array must have same size as 'args' Array" if at.is_a?(Array) && at.size != args.size
 

--- a/lib/sidekiq/job.rb
+++ b/lib/sidekiq/job.rb
@@ -248,9 +248,9 @@ module Sidekiq
       end
       alias_method :perform_sync, :perform_inline
 
-      def perform_bulk(args, batch_size: 1_000)
+      def perform_bulk(args, batch_size: 1_000, at: nil)
         client = @klass.build_client
-        client.push_bulk(@opts.merge("class" => @klass, "args" => args, :batch_size => batch_size))
+        client.push_bulk(@opts.merge("class" => @klass, "args" => args, :batch_size => batch_size, :at => at))
       end
 
       # +interval+ must be a timestamp, numeric or something that acts

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -426,6 +426,14 @@ describe Sidekiq::Client do
         assert_equal 1_001, jids.size
       end
 
+      it "pushes a large set of jobs with custom schedules" do
+        jids = MyJob.perform_bulk((1..1_001).to_a.map { |x| Array(x) }, at: [1] * 1_001)
+        assert_equal 1_001, jids.size
+
+        q = Sidekiq::ScheduledSet.new
+        assert_equal 1_001, q.size
+      end
+
       it "handles no jobs" do
         jids = MyJob.perform_bulk([])
         assert_equal 0, jids.size


### PR DESCRIPTION
Currently, if the user wants to bulk enqueue jobs, but with different schedules, he should use `Sidekiq::Client#push_bulk` low-level API. 

This PR adds support for this to `perform_bulk` (given that `batch_size` is already supported):
```ruby
MyJob.perform_bulk(args, at: timestamps)
```