### PR TITLE
use iteration_key method in Job::Iterable

### DIFF
--- a/lib/sidekiq/job/iterable.rb
+++ b/lib/sidekiq/job/iterable.rb
@@ -177,7 +177,7 @@ module Sidekiq
       private
 
       def is_cancelled?
-        @_cancelled = Sidekiq.redis { |c| c.hget("it-#{jid}", "cancelled") }
+        @_cancelled = Sidekiq.redis { |c| c.hget(iteration_key, "cancelled") }
       end
 
       def fetch_previous_iteration_state


### PR DESCRIPTION
This pull request makes a small update to the job cancellation logic in the `Sidekiq::Job::Iterable` module. The change ensures that the cancellation status is checked using the correct iteration key, which improves accuracy when determining if a job has been cancelled.

* Updated the `is_cancelled?` method to use `iteration_key` instead of a hardcoded key format when checking for job cancellation status in Redis.