### PR TITLE
Handle ActiveSupport::Logger.broadcast deprication

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -48,8 +48,10 @@ module Sidekiq
           unless ::Rails.logger == config.logger || ::ActiveSupport::Logger.logger_outputs_to?(::Rails.logger, $stdout)
             if ::Rails.logger.respond_to?(:broadcast_to)
               ::Rails.logger.broadcast_to(config.logger)
-            else
+            elsif ::ActiveSupport::Logger.respond_to?(:broadcast)
               ::Rails.logger.extend(::ActiveSupport::Logger.broadcast(config.logger))
+            else
+              ::Rails.logger = ::ActiveSupport::BroadcastLogger.new(Rails.logger, config.logger)
             end
           end
         end

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -51,7 +51,7 @@ module Sidekiq
             elsif ::ActiveSupport::Logger.respond_to?(:broadcast)
               ::Rails.logger.extend(::ActiveSupport::Logger.broadcast(config.logger))
             else
-              ::Rails.logger = ::ActiveSupport::BroadcastLogger.new(Rails.logger, config.logger)
+              ::Rails.logger = ::ActiveSupport::BroadcastLogger.new(::Rails.logger, config.logger)
             end
           end
         end


### PR DESCRIPTION
As per https://apidock.com/rails/ActiveSupport/Logger/broadcast/class ActiveSupport::Logger.broadcast is no longer supported after rails v7.0.0