### PR TITLE
Track discarded_at in job payload when job is discarded.

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -186,6 +186,8 @@ module Sidekiq
       strategy, delay = delay_for(jobinst, count, exception, msg)
       case strategy
       when :discard
+        msg["discarded_at"] = now_ms
+
         return run_death_handlers(msg, exception)
       when :kill
         return retries_exhausted(jobinst, msg, exception)
@@ -255,8 +257,14 @@ module Sidekiq
         handle_exception(e, {context: "Error calling retries_exhausted", job: msg})
       end
 
-      to_morgue = !(msg["dead"] == false || rv == :discard)
-      send_to_morgue(msg) if to_morgue
+      discarded = msg["dead"] == false || rv == :discard
+
+      if discarded
+        msg["discarded_at"] = now_ms
+      else
+        send_to_morgue(msg)
+      end
+
       run_death_handlers(msg, exception)
     end
 

--- a/test/retry_exhausted_test.rb
+++ b/test/retry_exhausted_test.rb
@@ -202,6 +202,7 @@ describe "sidekiq_retries_exhausted" do
     end
 
     assert exhausted_job
+    assert exhausted_job["discarded_at"]
     assert exhausted_exception
   end
 
@@ -224,6 +225,7 @@ describe "sidekiq_retries_exhausted" do
     assert DiscardJob.exhausted_called
     assert_equal 0, Sidekiq::DeadSet.new.size
     refute_nil exhausted_job
+    assert exhausted_job["discarded_at"]
     refute_nil exhausted_exception
   end
 

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -418,6 +418,7 @@ describe Sidekiq::JobRetry do
         end
         assert_equal 0, ds.size
         assert @job
+        assert @job["discarded_at"]
       end
 
       it "kills when configured on special exceptions" do


### PR DESCRIPTION
This allows death handlers to distinguish between jobs were discarded and jobs that were not.

Refer to https://github.com/sidekiq/sidekiq/issues/6741#issuecomment-3315046721 for context.