### PR TITLE
Add ability to extend sidekiq/api when it is loaded

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -29,6 +29,7 @@ end
 
 require "sidekiq/config"
 require "sidekiq/logger"
+require "sidekiq/loader"
 require "sidekiq/client"
 require "sidekiq/transaction_aware_client"
 require "sidekiq/job"
@@ -92,6 +93,10 @@ module Sidekiq
 
   def self.logger
     default_configuration.logger
+  end
+
+  def self.loader
+    @loader ||= Loader.new
   end
 
   def self.configure_server(&block)

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -1321,3 +1321,5 @@ module Sidekiq
     end
   end
 end
+
+Sidekiq.loader.run_load_hooks(:api)

--- a/lib/sidekiq/loader.rb
+++ b/lib/sidekiq/loader.rb
@@ -1,0 +1,35 @@
+module Sidekiq
+  class Loader
+    def initialize
+      @load_hooks = Hash.new { |h, k| h[k] = [] }
+      @loaded = Set.new
+    end
+
+    # Declares a block that will be executed when a Sidekiq component is fully
+    # loaded. If the component has already loaded, the block is executed
+    # immediately.
+    #
+    #   Sidekiq.loader.on_load(:api) do
+    #     # extend the sidekiq API
+    #   end
+    #
+    def on_load(name, &block)
+      @load_hooks[name] << block
+
+      if @loaded.include?(name)
+        @load_hooks[name].each(&:call)
+      end
+    end
+
+    # Executes all blocks registered to +name+ via on_load.
+    #
+    #   Sidekiq.loader.run_load_hooks(:api)
+    #
+    # In the case of the above example, it will execute all hooks registered for +:api+.
+    #
+    def run_load_hooks(name)
+      @loaded << name
+      @load_hooks[name].each(&:call)
+    end
+  end
+end

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -828,6 +828,12 @@ describe "API" do
       end
     end
   end
+
+  it "runs load hooks" do
+    ran = false
+    Sidekiq.loader.on_load(:api) { ran = true }
+    assert(ran)
+  end
 end
 
 FAKE_DATA = "H4sICNrWI2cAA3NvbWUuanNvbgCrVlDKTq1UslJQKkvMKU1V0lFQSiwqSgSJRBvqKBjpKBjHKtRyAQDd7Kt/JwAAAA=="

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require "sidekiq/loader"
+
+describe "loader" do
+  before do
+    @loader = Sidekiq::Loader.new
+  end
+
+  it "runs registered hooks after component was loaded" do
+    values = []
+    @loader.on_load(:foo) { values << "foo1" }
+    @loader.on_load(:foo) { values << "foo2" }
+    @loader.on_load(:bar) { values << "bar" }
+
+    @loader.run_load_hooks(:foo)
+
+    assert_equal(["foo1", "foo2"], values)
+
+    @loader.run_load_hooks(:bar)
+
+    assert_equal(["foo1", "foo2", "bar"], values)
+  end
+
+  it "runs registered hook immediately if the component is already loaded" do
+    @loader.run_load_hooks(:foo)
+
+    values = []
+    @loader.on_load(:foo) { values << "foo" }
+
+    assert_equal(["foo"], values)
+  end
+end


### PR DESCRIPTION
Relevant #6823.

The new api to the loader is like:
```ruby
Sidekiq.loader.on_load(:component) do
  # do something, e.g. extend the component
end

Sidekiq.loader.run_load_hooks(:component)
```

A similar API to what Rails uses https://github.com/rails/rails/blob/main/activesupport/lib/active_support/lazy_load_hooks.rb

The loader is currently accessible via `Sidekiq.loader`, but can change to `Sidekiq::Loader` only if we want for it to be a private API and less discoverable. 