### PR TITLE
doc: clarify :at option in perform_bulk and push_bulk

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -117,6 +117,11 @@ module Sidekiq
     # larger than 1000 but YMMV based on network quality, size of job args, etc.
     # A large number of jobs can cause a bit of Redis command processing latency.
     #
+    # Accepts an `:at` option to schedule the jobs for future execution. It
+    # accepts either a single Numeric timestamp (or seconds-from-now) applied
+    # to every job, or an Array of Numeric values with the same size as `args`
+    # to schedule each job at its corresponding time.
+    #
     # Accepts an additional `:spread_interval` option (in seconds) to randomly spread
     # the jobs schedule times over the specified interval.
     #

--- a/lib/sidekiq/job.rb
+++ b/lib/sidekiq/job.rb
@@ -313,6 +313,11 @@ module Sidekiq
       #
       # +items+ must be an Array of Arrays.
       #
+      # The +:at+ option schedules the jobs for future execution. It accepts
+      # either a single Numeric timestamp (or seconds-from-now) applied to every
+      # job, or an Array of Numeric values with the same size as +items+ to
+      # schedule each job at its corresponding time.
+      #
       # For finer-grained control, use `Sidekiq::Client.push_bulk` directly.
       #
       # Example (3 Redis round trips):
@@ -324,6 +329,14 @@ module Sidekiq
       # Would instead become (1 Redis round trip):
       #
       #     SomeJob.perform_bulk([[1], [2], [3]])
+      #
+      # Scheduling every job 60 seconds from now (single Numeric +:at+):
+      #
+      #     SomeJob.perform_bulk([[1], [2], [3]], at: 60)
+      #
+      # Scheduling each job at its own time (Array +:at+):
+      #
+      #     SomeJob.perform_bulk([[1], [2]], at: [Time.now.to_f + 30, Time.now.to_f + 60])
       #
       def perform_bulk(*args, **kwargs)
         Setter.new(self, {}).perform_bulk(*args, **kwargs)


### PR DESCRIPTION
## Summary
- Document the `:at` option on `Sidekiq::Job.perform_bulk` (in `lib/sidekiq/job.rb`), explicitly noting it accepts either a single Numeric timestamp (applied to every job) or an Array of Numerics (one per job).
- Mirror the same `:at` description on `Sidekiq::Client#push_bulk` (in `lib/sidekiq/client.rb`), which previously only documented `:spread_interval`.
- Add two short usage examples showing both forms of `:at`.

Docs-only change — no behavior changes.

## Test plan
- [x] No code changes; existing test suite should remain green.