### PR TITLE
  tui: implement locale-aware number_with_delimiter                                                                                                                                                        

### DIFF
--- a/lib/sidekiq/tui.rb
+++ b/lib/sidekiq/tui.rb
@@ -21,6 +21,8 @@ module Sidekiq
     REFRESH_INTERVAL_SECONDS = 2
     LOCALE_DIRECTORIES = [File.expand_path("#{File.dirname(__FILE__)}/../../web/locales")]
 
+    attr_reader :lang
+
     # language is meant to be a locale code, e.g.
     # LANG=en_US.utf-8
     def initialize(cfg, language: ENV["LANG"] || "en")

--- a/lib/sidekiq/tui/tabs/base_tab.rb
+++ b/lib/sidekiq/tui/tabs/base_tab.rb
@@ -154,7 +154,7 @@ module Sidekiq
 
         # Format keys and values with spacing
         keys_line = keys.map { |k| t(k).to_s.ljust(12) }.join("  ")
-        values_line = values.map { |v| v.to_s.ljust(12) }.join("  ")
+        values_line = values.map { |v| number_with_delimiter(v).ljust(12) }.join("  ")
 
         frame.render_widget(
           tui.paragraph(
@@ -165,10 +165,27 @@ module Sidekiq
         )
       end
 
-      # TODO Implement I18n delimiter
+      # [thousands_separator, decimal_separator] per locale.
+      # Locales not listed here use the English default [",", "."].
+      NUMERIC_SEPARATORS = {
+        # period thousands, comma decimal
+        "da" => [".", ","], "de" => [".", ","], "el" => [".", ","],
+        "es" => [".", ","], "it" => [".", ","], "nl" => [".", ","],
+        "pt" => [".", ","], "pt-BR" => [".", ","], "tr" => [".", ","],
+        "vi" => [".", ","],
+        # space thousands, comma decimal
+        "cs" => [" ", ","], "fr" => [" ", ","], "lt" => [" ", ","],
+        "nb" => [" ", ","], "pl" => [" ", ","], "ru" => [" ", ","],
+        "sv" => [" ", ","], "uk" => [" ", ","]
+      }.freeze
+
       def number_with_delimiter(number, options = {})
         precision = options[:precision] || 0
-        number.round(precision)
+        rounded = number.round(precision)
+        thousands, decimal = NUMERIC_SEPARATORS.fetch(@parent.lang, [",", "."])
+        integer_part, decimal_part = rounded.to_s.split(".")
+        integer_with_sep = integer_part.gsub(/(\d)(?=(\d{3})+(?!\d))/, "\\1#{thousands}")
+        precision > 0 ? "#{integer_with_sep}#{decimal}#{(decimal_part || "").ljust(precision, "0")}" : integer_with_sep
       end
 
       def format_memory(rss_kb)

--- a/test/tui_test.rb
+++ b/test/tui_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+
+# Load TUI internals without pulling in ratatui_ruby (which is a :tui group gem)
+module Sidekiq
+  class TUI
+  end
+end
+require "sidekiq/tui/controls"
+require "sidekiq/tui/tabs/base_tab"
+
+class FakeTUIParent
+  attr_reader :lang
+
+  def initialize(lang = "en")
+    @lang = lang
+  end
+
+  def t(key) = key.to_s
+end
+
+class ConcreteTab < Sidekiq::TUI::BaseTab
+  def refresh_data
+  end
+end
+
+describe "Sidekiq::TUI::BaseTab" do
+  describe "#number_with_delimiter" do
+    it "returns small numbers as strings without modification" do
+      tab = ConcreteTab.new(FakeTUIParent.new)
+      assert_equal "0", tab.number_with_delimiter(0)
+      assert_equal "999", tab.number_with_delimiter(999)
+    end
+
+    it "inserts comma separators for thousands in English locale" do
+      tab = ConcreteTab.new(FakeTUIParent.new("en"))
+      assert_equal "1,000", tab.number_with_delimiter(1_000)
+      assert_equal "1,234,567", tab.number_with_delimiter(1_234_567)
+      assert_equal "1,500,000,000", tab.number_with_delimiter(1_500_000_000)
+    end
+
+    it "rounds and formats decimal numbers with precision in English locale" do
+      tab = ConcreteTab.new(FakeTUIParent.new("en"))
+      assert_equal "15.68", tab.number_with_delimiter(15.678, precision: 2)
+      assert_equal "1,234.50", tab.number_with_delimiter(1234.5, precision: 2)
+      assert_equal "3,932.00", tab.number_with_delimiter(3932.0, precision: 2)
+    end
+
+    it "uses period thousands separator and comma decimal for German locale" do
+      tab = ConcreteTab.new(FakeTUIParent.new("de"))
+      assert_equal "1.234.567", tab.number_with_delimiter(1_234_567)
+      assert_equal "1.234,50", tab.number_with_delimiter(1234.5, precision: 2)
+    end
+
+    it "uses space thousands separator and comma decimal for French locale" do
+      tab = ConcreteTab.new(FakeTUIParent.new("fr"))
+      assert_equal "1 234 567", tab.number_with_delimiter(1_234_567)
+      assert_equal "1 234,50", tab.number_with_delimiter(1234.5, precision: 2)
+    end
+
+    it "falls back to English separators for locales not in the map" do
+      tab = ConcreteTab.new(FakeTUIParent.new("ja"))
+      assert_equal "1,234,567", tab.number_with_delimiter(1_234_567)
+    end
+  end
+
+  describe "#format_memory" do
+    it "returns 0 for nil or zero rss" do
+      tab = ConcreteTab.new(FakeTUIParent.new)
+      assert_equal "0", tab.format_memory(nil)
+      assert_equal "0", tab.format_memory(0)
+    end
+
+    it "formats values under 100_000 KB as KB with delimiter" do
+      tab = ConcreteTab.new(FakeTUIParent.new)
+      assert_equal "512 KB", tab.format_memory(512)
+      assert_equal "99,999 KB", tab.format_memory(99_999)
+    end
+
+    it "converts values between 100_000 and 10_000_000 KB to MB" do
+      tab = ConcreteTab.new(FakeTUIParent.new)
+      assert_equal "100 MB", tab.format_memory(102_400)
+    end
+
+    it "converts values over 10_000_000 KB to GB with one decimal" do
+      tab = ConcreteTab.new(FakeTUIParent.new)
+      assert_match(/\d+\.\d GB/, tab.format_memory(11_000_000))
+    end
+
+    it "uses locale-aware separators in memory formatting" do
+      tab = ConcreteTab.new(FakeTUIParent.new("de"))
+      assert_equal "99.999 KB", tab.format_memory(99_999)
+    end
+  end
+end


### PR DESCRIPTION
  The `number_with_delimiter` helper in `Sidekiq::TUI::BaseTab` had a                                                                                                                                      
  `# TODO Implement I18n delimiter` comment — it only rounded numbers                                                                                                                                    
  without any formatting.                                                                                                                                                                                  
                         
  This PR resolves that TODO by implementing locale-aware formatting                                                                                                                                       
  using a `NUMERIC_SEPARATORS` map covering all 30 supported Sidekiq                                                                                                                                       
  locales:                                                          
                                                                                                                                                                                                           
  - `en`, `ja`, `zh-CN` and others → `1,234,567`                                                                                                                                                         
  - `de`, `it`, `nl` and others → `1.234.567`                                                                                                                                                              
  - `fr`, `ru`, `sv` and others → `1 234 567`
                                                                                                                                                                                                           
  **Changes:**                                                                                                                                                                                           
  - Add `attr_reader :lang` to `Sidekiq::TUI` so tabs can read the active locale                                                                                                                           
  - Add `NUMERIC_SEPARATORS` map in `BaseTab` keyed by locale code                                                                                                                                       
  - Fix the Statistics bar which was bypassing `number_with_delimiter` entirely, using raw `.to_s` on job counts
  - Add `test/tui_test.rb` — the first test file for the TUI layer, covering both `number_with_delimiter` and `format_memory` 

**Before**
<img width="1437" height="745" alt="before_final" src="https://github.com/user-attachments/assets/3ebfed72-55c4-4fab-9225-9dd4340e775a" />


**After**
   **German**
   
<img width="1707" height="896" alt="after_de" src="https://github.com/user-attachments/assets/fb84dee1-45cf-491b-8df1-441d4d6b596d" />


  **English**
  
<img width="1703" height="902" alt="after_en" src="https://github.com/user-attachments/assets/f236859e-3bb5-4f7a-80d4-002c692ca4ec" />


