### PR TITLE
Identify Sidekiq connections via CLIENT SETINFO

### DIFF
--- a/lib/sidekiq/redis_client_adapter.rb
+++ b/lib/sidekiq/redis_client_adapter.rb
@@ -107,6 +107,10 @@ module Sidekiq
       # on by default.
       opts[:reconnect_attempts] ||= 1
 
+      # Identify ourselves to Redis via CLIENT SETINFO so connections
+      # are distinguishable in CLIENT LIST / CLIENT INFO output.
+      opts[:driver_info] ||= "sidekiq_v#{Sidekiq::VERSION}"
+
       opts
     end
   end

--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
     "rubygems_mfa_required" => "true"
   }
 
-  gem.add_dependency "redis-client", ">= 0.26.0"
+  gem.add_dependency "redis-client", ">= 0.29.0"
   gem.add_dependency "connection_pool", ">= 3.0.0"
   gem.add_dependency "rack", ">= 3.2.0"
   gem.add_dependency "json", ">= 2.16.0"

--- a/test/redis_connection_test.rb
+++ b/test/redis_connection_test.rb
@@ -146,6 +146,22 @@ describe Sidekiq::RedisConnection do
       end
     end
 
+    describe "driver_info" do
+      it "identifies sidekiq by default" do
+        pool = Sidekiq::RedisConnection.create
+        config = config_for(pool.checkout)
+
+        assert_equal "sidekiq_v#{Sidekiq::VERSION}", config.driver_info
+      end
+
+      it "preserves a user-provided driver_info" do
+        pool = Sidekiq::RedisConnection.create(driver_info: "custom-app-1.2.3")
+        config = config_for(pool.checkout)
+
+        assert_equal "custom-app-1.2.3", config.driver_info
+      end
+    end
+
     describe "logging redis options" do
       it "redacts credentials" do
         options = {


### PR DESCRIPTION
## What

Bumps the `redis-client` floor to `>= 0.27.0` and uses its new `driver_info` config to identify Sidekiq on every Redis connection via `CLIENT SETINFO`.

## Why

Connections from Sidekiq, the host app's `redis` gem, Rails cache, etc. are currently indistinguishable in `CLIENT LIST` / `CLIENT INFO`.
`redis-client` 0.27.0 (released Mar 2026) added `driver_info:` to set `LIB-NAME` automatically during the connection prelude.

After this change, ops will see:

    lib-name=redis-client(sidekiq_v8.1.3) lib-ver=0.28.0

per Sidekiq connection, matching the `<driver>_v<version>` convention used accross the econsystem. 

Stacking is supported — users can override:

```ruby
config.redis = { driver_info: "sidekiq_v#{Sidekiq::VERSION};myapp_v1.0" }