### PR TITLE
Fix: don't cache "none" type in Paginator::TYPE_CACHE

### DIFF
--- a/lib/sidekiq/paginator.rb
+++ b/lib/sidekiq/paginator.rb
@@ -23,7 +23,8 @@ module Sidekiq
         elsif key.start_with?("queue:")
           type = TYPE_CACHE[key] = "list"
         else
-          type = TYPE_CACHE[key] = conn.type(key)
+          type = conn.type(key)
+          TYPE_CACHE[key] = type unless type == "none"
         end
         rev = opts && opts[:reverse]
 


### PR DESCRIPTION
Skip caching when `type == "none"` so transient absence is rechecked on the next request.

TYPE_CACHE stores Redis key types to avoid repeated TYPE calls. However, it also caches "none" — the value Redis returns when a key doesn't exist yet. This permanently poisons the cache for that key until process restart, causing UI pages (e.g. Batches) to always return empty even after the key is created.
