### PR TITLE
Require sidekiq in sidekiq/testing deprecation shim

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -1,2 +1,3 @@
+require "sidekiq"
 Sidekiq.testing!(:fake)
 warn('⛔️ `require "sidekiq/testing"` is deprecated and will be removed in Sidekiq 9.0. See https://sidekiq.org/wiki/Testing#new-api')


### PR DESCRIPTION
Fixes https://github.com/sidekiq/sidekiq/issues/6993

The 8.1.1 deprecation shim at `lib/sidekiq/testing.rb` calls `Sidekiq.testing!(:fake)` without requiring `sidekiq` itself. Users whose `spec_helper.rb` only loaded `sidekiq/testing` now hit `NameError: uninitialized constant Sidekiq`. Adding `require "sidekiq"` back to the shim restores the old behavior while keeping the deprecation warning intact.