### PR TITLE
Fix flaky queue_summaries latency test

### DIFF
--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -157,12 +157,12 @@ describe "API" do
 
         assert_equal "bar", result[0].name
         assert_equal 3, result[0].size
-        assert_in_delta 0.10, result[0].latency, 0.01
+        assert_operator result[0].latency, :>, 0.09
         assert_equal true, result[0].paused?
 
         assert_equal "foo", result[1].name
         assert_equal 1, result[1].size
-        assert_in_delta 0.05, result[1].latency, 0.01
+        assert_operator result[1].latency, :>, 0.04
         assert_equal false, result[1].paused?
       end
     end


### PR DESCRIPTION
The `queue_summaries` test asserts latency within a 10ms window, which is tight enough that slow CI runners regularly trip it (e.g. `Expected |0.05 - 0.076| (0.026) to be <= 0.01`). This switches the assertions to lower-bound `assert_operator` checks, matching the pattern used a few lines below in the `enqueued` test.