### PR TITLE
Add RingBuffer tests and expand SdNotify coverage

### DIFF
--- a/test/ring_buffer_test.rb
+++ b/test/ring_buffer_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require "sidekiq/ring_buffer"
+
+describe Sidekiq::RingBuffer do
+  it "fills with the default value of zero" do
+    rb = Sidekiq::RingBuffer.new(3)
+    assert_equal [0, 0, 0], rb.to_a
+    assert_equal 3, rb.size
+  end
+
+  it "fills with a custom default value" do
+    rb = Sidekiq::RingBuffer.new(3, 7)
+    assert_equal [7, 7, 7], rb.to_a
+  end
+
+  it "returns the element that was pushed" do
+    rb = Sidekiq::RingBuffer.new(3)
+    assert_equal 42, (rb << 42)
+  end
+
+  it "fills slots in order before wrapping" do
+    rb = Sidekiq::RingBuffer.new(3)
+    rb << 1
+    rb << 2
+    assert_equal [1, 2, 0], rb.buffer
+  end
+
+  it "overwrites the oldest slot once full" do
+    rb = Sidekiq::RingBuffer.new(3)
+    [1, 2, 3, 4].each { |n| rb << n }
+    # index 0 (holding 1) is overwritten by 4; 2 and 3 remain
+    assert_equal [4, 2, 3], rb.buffer
+  end
+
+  it "exactly fills the buffer at capacity" do
+    rb = Sidekiq::RingBuffer.new(3)
+    [1, 2, 3].each { |n| rb << n }
+    assert_equal [1, 2, 3], rb.buffer
+  end
+
+  it "wraps repeatedly for more than two full cycles" do
+    rb = Sidekiq::RingBuffer.new(3)
+    (1..7).each { |n| rb << n }
+    # slot 0: 1,4,7 -> 7; slot 1: 2,5 -> 5; slot 2: 3,6 -> 6
+    assert_equal [7, 5, 6], rb.buffer
+  end
+
+  it "delegates [] to the underlying buffer" do
+    rb = Sidekiq::RingBuffer.new(3)
+    rb << 10
+    rb << 20
+    assert_equal 10, rb[0]
+    assert_equal 20, rb[1]
+    assert_equal 0, rb[2]
+  end
+
+  it "supports Enumerable methods" do
+    rb = Sidekiq::RingBuffer.new(3)
+    [1, 2, 3].each { |n| rb << n }
+    assert_equal [2, 4, 6], rb.map { |n| n * 2 }
+    assert_equal 6, rb.sum
+  end
+
+  it "exposes the underlying buffer" do
+    rb = Sidekiq::RingBuffer.new(2)
+    assert_equal [0, 0], rb.buffer
+  end
+
+  it "resets to the default value" do
+    rb = Sidekiq::RingBuffer.new(3)
+    [1, 2, 3].each { |n| rb << n }
+    rb.reset
+    assert_equal [0, 0, 0], rb.buffer
+  end
+
+  it "resets to a custom value" do
+    rb = Sidekiq::RingBuffer.new(3)
+    [1, 2, 3].each { |n| rb << n }
+    rb.reset(9)
+    assert_equal [9, 9, 9], rb.buffer
+  end
+
+  it "keeps writing to the correct slot after a reset" do
+    rb = Sidekiq::RingBuffer.new(3)
+    [1, 2, 3, 4].each { |n| rb << n }
+    rb.reset
+    rb << 99
+    # @index continued from 4, so 99 lands in slot 4 % 3 == 1
+    assert_equal [0, 99, 0], rb.buffer
+  end
+end

--- a/test/systemd_test.rb
+++ b/test/systemd_test.rb
@@ -23,7 +23,7 @@ describe "Systemd" do
   end
 
   def socket_message
-    @socket.recvfrom(10)[0]
+    @socket.recvfrom(50)[0]
   end
 
   it "notifies" do
@@ -38,5 +38,110 @@ describe "Systemd" do
     assert_equal(count, 10)
 
     refute Sidekiq::SdNotify.watchdog?
+  end
+
+  it "sends the reloading payload" do
+    Sidekiq::SdNotify.reloading
+    assert_equal "RELOADING=1", socket_message
+  end
+
+  it "sends a custom status payload" do
+    Sidekiq::SdNotify.status("doing work")
+    assert_equal "STATUS=doing work", socket_message
+  end
+
+  it "sends an errno payload" do
+    Sidekiq::SdNotify.errno(3)
+    assert_equal "ERRNO=3", socket_message
+  end
+
+  it "sends the main pid payload" do
+    Sidekiq::SdNotify.mainpid(123)
+    assert_equal "MAINPID=123", socket_message
+  end
+
+  it "sends the fdstore payload" do
+    Sidekiq::SdNotify.fdstore
+    assert_equal "FDSTORE=1", socket_message
+  end
+
+  it "removes NOTIFY_SOCKET from the env when unset_env is true" do
+    Sidekiq::SdNotify.ready(true)
+    assert_nil ENV["NOTIFY_SOCKET"]
+  end
+
+  it "keeps NOTIFY_SOCKET in the env by default" do
+    Sidekiq::SdNotify.ready
+    assert_equal @sockaddr, ENV["NOTIFY_SOCKET"]
+  end
+
+  it "raises NotifyError when the socket cannot be reached" do
+    ENV["NOTIFY_SOCKET"] = "/nonexistent/sidekiq/missing.sock"
+    assert_raises(Sidekiq::SdNotify::NotifyError) do
+      Sidekiq::SdNotify.notify("READY=1")
+    end
+  end
+end
+
+describe "Sidekiq::SdNotify without systemd" do
+  def restore_env(key, value)
+    value.nil? ? ENV.delete(key) : (ENV[key] = value)
+  end
+
+  before do
+    @orig = ENV.values_at("NOTIFY_SOCKET", "WATCHDOG_USEC", "WATCHDOG_PID")
+    ENV.delete("NOTIFY_SOCKET")
+    ENV.delete("WATCHDOG_USEC")
+    ENV.delete("WATCHDOG_PID")
+  end
+
+  after do
+    restore_env("NOTIFY_SOCKET", @orig[0])
+    restore_env("WATCHDOG_USEC", @orig[1])
+    restore_env("WATCHDOG_PID", @orig[2])
+  end
+
+  it "returns nil from notify when NOTIFY_SOCKET is unset" do
+    assert_nil Sidekiq::SdNotify.notify("READY=1")
+  end
+
+  it "returns nil from the convenience helpers with no socket" do
+    assert_nil Sidekiq::SdNotify.ready
+    assert_nil Sidekiq::SdNotify.stopping
+  end
+
+  describe "watchdog?" do
+    it "is false when WATCHDOG_USEC is unset" do
+      refute Sidekiq::SdNotify.watchdog?
+    end
+
+    it "is false when WATCHDOG_USEC is not an integer" do
+      ENV["WATCHDOG_USEC"] = "abc"
+      refute Sidekiq::SdNotify.watchdog?
+    end
+
+    it "is false when WATCHDOG_USEC is zero or negative" do
+      ENV["WATCHDOG_USEC"] = "0"
+      refute Sidekiq::SdNotify.watchdog?
+      ENV["WATCHDOG_USEC"] = "-5"
+      refute Sidekiq::SdNotify.watchdog?
+    end
+
+    it "is true for a valid usec when WATCHDOG_PID is unset" do
+      ENV["WATCHDOG_USEC"] = "100"
+      assert Sidekiq::SdNotify.watchdog?
+    end
+
+    it "is true when WATCHDOG_PID matches the current process" do
+      ENV["WATCHDOG_USEC"] = "100"
+      ENV["WATCHDOG_PID"] = $$.to_s
+      assert Sidekiq::SdNotify.watchdog?
+    end
+
+    it "is false when WATCHDOG_PID is another process" do
+      ENV["WATCHDOG_USEC"] = "100"
+      ENV["WATCHDOG_PID"] = ($$ + 1).to_s
+      refute Sidekiq::SdNotify.watchdog?
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds unit-test coverage for two previously thinly-tested units. No `lib/` changes.

- **`Sidekiq::RingBuffer`** had no test file. New `test/ring_buffer_test.rb` covers the default/custom fill, that `<<` returns the element, sequential fill, wraparound (`@index % @size`) at capacity / one past / multiple cycles, `[]`/`each`/`size` delegation, `Enumerable`, `buffer`, and `reset`. It also pins the subtle invariant that `reset` fills the buffer without resetting the write index.
- **`Sidekiq::SdNotify`** was only partially covered by `test/systemd_test.rb` (`ready`/`stopping`/`watchdog?` false). Extended it with the remaining payloads (`reloading`/`status`/`errno`/`mainpid`/`fdstore`), the no-socket no-op path, `NotifyError` on an unreachable socket, `unset_env`, and the full `watchdog?` matrix. The receive buffer was bumped 10→50 bytes so longer payloads (e.g. `STATUS=...`) aren't truncated.

## Testing

`bundle exec rake` is green (standard + lint:herb + 564 tests). The new files pass under multiple seeds with no ENV leakage between examples.