### PR TITLE
Remove parse_yaml_old from web helpers

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -72,13 +72,13 @@ module Sidekiq
       # so extensions can be localized
       @@strings[lang] ||= config.locales.each_with_object({}) do |path, global|
         find_locale_files(lang).each do |file|
-          strs = parse_yaml_new(file)
+          strs = parse_yaml(file)
           global.merge!(strs[lang])
         end
       end
     end
 
-    def parse_yaml_new(path)
+    def parse_yaml(path)
       locale = nil
       map = {}
       IO.readlines(path, chomp: true).each do |line|

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -78,12 +78,6 @@ module Sidekiq
       end
     end
 
-    # TODO Remove
-    def parse_yaml_old(path)
-      require "yaml"
-      YAML.safe_load_file(path)
-    end
-
     def parse_yaml_new(path)
       locale = nil
       map = {}

--- a/test/web_helpers_test.rb
+++ b/test/web_helpers_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "helper"
 require "sidekiq/web"
+require "yaml"
 
 class Helpers
   include Sidekiq::WebHelpers
@@ -272,9 +273,7 @@ describe "Web helpers" do
     it "can parse locale files" do
       obj = Helpers.new
       Dir["web/locales/*.yml"].each do |path|
-        # p path
-        # path = "web/locales/en.yml"
-        ex = obj.parse_yaml_old(path)
+        ex = YAML.safe_load_file(path)
         was = obj.parse_yaml_new(path)
         assert_equal path, "web/locales/#{was.keys.first}.yml"
         ex.values.first.zip(was.values.first).each do |expected, got|

--- a/test/web_helpers_test.rb
+++ b/test/web_helpers_test.rb
@@ -274,7 +274,7 @@ describe "Web helpers" do
       obj = Helpers.new
       Dir["web/locales/*.yml"].each do |path|
         ex = YAML.safe_load_file(path)
-        was = obj.parse_yaml_new(path)
+        was = obj.parse_yaml(path)
         assert_equal path, "web/locales/#{was.keys.first}.yml"
         ex.values.first.zip(was.values.first).each do |expected, got|
           assert_equal expected, got


### PR DESCRIPTION
## Summary

Commit 25afb793 (#6950) replaced YAML-based locale parsing with a custom parser to keep YAML off the web request path, but left `parse_yaml_old` behind — marked `# TODO Remove` and used only as a test oracle. It still pulled `require "yaml"` + `YAML.safe_load_file` into `web/helpers.rb`.

- Remove `parse_yaml_old` (and its `# TODO Remove`); `parse_yaml_new` is already the sole production parser via `strings`.
- The "can parse locale files" test keeps its exact oracle cross-check by calling `YAML.safe_load_file(path)` directly (tests may use YAML — the security boundary is production web code). Also drops two dead debug comments.

`git grep parse_yaml_old` is now empty.

## Testing

`bundle exec rake` is green (standard + lint:herb + full suite).