### PR TITLE
Forward block through RedisClientAdapter#method_missing

### DIFF
--- a/lib/sidekiq/redis_client_adapter.rb
+++ b/lib/sidekiq/redis_client_adapter.rb
@@ -41,8 +41,8 @@ module Sidekiq
       # this allows us to use methods like `conn.hmset(...)` instead of having to use
       # redis-client's native `conn.call("hmset", ...)`
       def method_missing(*args, &block)
-        warn("[sidekiq#5788] Redis has deprecated the `#{args.first}`command, called at #{caller(1..1)}") if DEPRECATED_COMMANDS.include?(args.first)
-        @client.call(*args, *block)
+        warn("[sidekiq#5788] Redis has deprecated the `#{args.first}` command, called at #{caller(1..1)}") if DEPRECATED_COMMANDS.include?(args.first)
+        @client.call(*args, &block)
       end
       ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 

--- a/test/redis_connection_test.rb
+++ b/test/redis_connection_test.rb
@@ -304,3 +304,19 @@ describe Sidekiq::RedisConnection do
     end
   end
 end
+
+describe Sidekiq::RedisClientAdapter do
+  before do
+    @config = reset!
+  end
+
+  # Commands not in USED_COMMANDS are routed through method_missing, which must
+  # forward a result-transformation block to redis-client. Regression guard: the
+  # block was being splatted as a positional argument instead of forwarded.
+  it "forwards a block through method_missing" do
+    @config.redis do |conn|
+      result = conn.echo("hello") { |reply| reply.upcase }
+      assert_equal "HELLO", result
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`RedisClientAdapter::CompatMethods#method_missing` captured its block but forwarded it with a positional splat (`*block`) instead of as a block (`&block`):

```ruby
def method_missing(*args, &block)
  ...
  @client.call(*args, *block)   # bug: splats the Proc as a positional arg
end
```

Commands routed through `method_missing` (those outside `USED_COMMANDS`) that pass a redis-client result-transformation block — the same mechanism the adapter's own `info` uses (`@client.call("INFO") { |i| ... }`) — get the `Proc` splatted into the command arguments, which raises `TypeError: Unsupported command argument type: Proc` in redis-client's command builder.

With no block, `*block` is `*nil` → a no-op, which is why every existing caller was unaffected and the defect (present since the adapter was introduced in f38cf305) stayed latent.

Fix: forward the block with `&block`. While here, add the missing space in the adjacent deprecation `warn` string (``` `cmd`command ``` → ``` `cmd` command ```).

## Testing

Added a regression test that routes `echo` (not in `USED_COMMANDS`) through `method_missing` with a transform block — it raises on the old `*block` and returns the transformed reply with `&block`. `bundle exec rake` is green (standard + lint:herb + full suite).