### PR TITLE
Fix sub-second precision in JobRetry#time_for

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 8.1.5
 ----------
 
+- Fix sub-second precision when computing the `retry_for` deadline [#7003]
 - Identify Sidekiq connnections in Redis with `CLIENT SETINFO` [#6986]
 - Fix edge case where Web UI could show an empty Batch set [#6987]
 

--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -211,7 +211,7 @@ module Sidekiq
       if item.is_a?(Float)
         Time.at(item)
       else
-        Time.at(item / 1000, item % 1000)
+        Time.at(item / 1000, item % 1000, :millisecond)
       end
     end
 

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -97,6 +97,18 @@ describe Sidekiq::JobRetry do
       Sidekiq::RetrySet.new.first
     end
 
+    describe "#time_for" do
+      it "converts integer millisecond timestamps with sub-second precision" do
+        ms = 1_700_000_000_500
+        assert_in_delta 1_700_000_000.5, handler.send(:time_for, ms).to_f, 0.0001
+      end
+
+      it "passes through legacy float (epoch seconds) timestamps" do
+        secs = 1_700_000_000.5
+        assert_in_delta secs, handler.send(:time_for, secs).to_f, 0.0001
+      end
+    end
+
     it "retries with a nil worker" do
       assert_raises RuntimeError do
         handler.global(jobstr, "default") do


### PR DESCRIPTION
## Summary

`JobRetry#time_for` converts an epoch-millisecond integer to a `Time`, but passes the millisecond remainder to the 2-argument `Time.at`, which interprets its second argument as **microseconds**:

```ruby
Time.at(item / 1000, item % 1000)   # item % 1000 is milliseconds, not microseconds
```

So the sub-second part is 1000× too small — up to ~0.999s of precision is silently dropped (e.g. `1_700_000_000_500` → `…000.0005s` instead of `…000.500s`).

`failed_at` is stored as integer milliseconds (`now_ms`), so this `else` branch is the live path (the `Float` branch is legacy epoch-seconds). The single caller is the `retry_for` deadline check:

```ruby
return retries_exhausted(...) if (time_for(msg["failed_at"]) + rf) < Time.now
```

so duration-based retry deadlines were evaluated up to ~1s early. Introduced in 705ac9a4 (#6564) when `failed_at` switched from epoch float to epoch millis.

## Fix

Pass the `:millisecond` unit so the remainder is interpreted correctly:

```ruby
Time.at(item / 1000, item % 1000, :millisecond)
```

Exact integer math, leaves the legacy `Float` path untouched, and `:millisecond` is supported on Ruby 3.2+ (Sidekiq's minimum).

## Testing

Added a `#time_for` regression test (integer-ms with a sub-second part, plus the legacy float pass-through). It fails on the old code (~0.4995s off) and passes after the fix. `bundle exec rake` is green (standard + lint:herb + full suite).