### PR TITLE
Fix chained `set(wait:)` scheduling

### DIFF
--- a/lib/sidekiq/job.rb
+++ b/lib/sidekiq/job.rb
@@ -196,7 +196,7 @@ module Sidekiq
 
       def set(options)
         hash = options.transform_keys(&:to_s)
-        interval = hash.delete("wait_until") || @opts.delete("wait")
+        interval = hash.delete("wait_until") || hash.delete("wait")
         @opts.merge!(hash)
         at(interval) if interval
         self

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -130,6 +130,19 @@ describe Sidekiq::Job do
       assert_equal "xyz", job["bar"]
     end
 
+    it "schedules jobs when wait is set in a chained call" do
+      q = Sidekiq::ScheduledSet.new
+      q.clear
+      assert_equal 0, q.size
+
+      assert MySetJob.set(queue: :bar).set(wait: 1.hour).perform_async(1)
+
+      assert_equal 1, q.size
+      job = q.first
+      assert_equal "bar", job["queue"]
+      assert_equal [1], job["args"]
+    end
+
     it "can detect when stopping" do
       refute MySetJob.new.interrupted?
     end


### PR DESCRIPTION
Fixes #7004.

`Sidekiq::Job::Setter#set` was reading `"wait"` from `@opts` instead of the incoming options hash, so a chained call like:

```ruby
SomeJob.set(queue: "default").set(wait: 10).perform_async(123)
```

would enqueue immediately instead of scheduling the job.

This keeps the change narrow:
- read `"wait"` from the new options hash in `Setter#set`
- add a regression test for the chained `set(wait:)` path

Local verification:
- `ruby -c lib/sidekiq/job.rb`
- `ruby -c test/job_test.rb`
- ad hoc bundled Ruby probe for `SomeJob.set(...).set(wait: ...).perform_async(...)` confirming an `"at"` timestamp is produced

I could not run `test/job_test.rb` end-to-end in this environment because there is no Redis daemon listening on `127.0.0.1:6379`.
