### PR TITLE
Add tests for Web UI HTML-escaping helpers

### DIFF
--- a/test/web_helpers_test.rb
+++ b/test/web_helpers_test.rb
@@ -202,6 +202,53 @@ describe "Web helpers" do
     assert_equal "direction=H%3EB&page=B%3CH", obj.qparams("page" => "B<H")
   end
 
+  describe "#h" do
+    it "escapes HTML special characters" do
+      obj = Helpers.new
+      assert_equal "&lt;a&gt; &amp; &quot;x&quot; &#39;y&#39;", obj.h(%q(<a> & "x" 'y'))
+    end
+
+    it "coerces non-strings before escaping" do
+      obj = Helpers.new
+      assert_equal "123", obj.h(123)
+    end
+  end
+
+  describe "#filter_link" do
+    it "escapes the value and wraps it in a filter link by default" do
+      obj = Helpers.new
+      assert_equal "<a href='/retries?substr=ab&lt;c'>ab&lt;c</a>", obj.filter_link("ab<c")
+    end
+
+    it "returns only the escaped value when within is nil" do
+      obj = Helpers.new
+      assert_equal "ab&lt;c", obj.filter_link("ab<c", nil)
+    end
+  end
+
+  describe "#display_tags" do
+    it "escapes tag content in both the label and the filter link" do
+      obj = Helpers.new
+      job = Struct.new(:tags).new(["a<b"])
+      result = obj.display_tags(job)
+      assert_includes result, "jobtag-a&lt;b"
+      assert_includes result, "substr=a&lt;b"
+    end
+  end
+
+  describe "#to_query_string" do
+    it "keeps safe params, drops unknown ones, and escapes values" do
+      obj = Helpers.new
+      qs = obj.to_query_string("page" => "2", "jid" => "abc", "direction" => "asc", "only" => "working")
+      assert_equal "page=2&direction=asc&only=working", qs
+    end
+
+    it "escapes reserved characters in values" do
+      obj = Helpers.new
+      assert_equal "page=a+b%26c", obj.to_query_string("page" => "a b&c")
+    end
+  end
+
   describe "#format_memory" do
     it "returns in KB" do
       obj = Helpers.new


### PR DESCRIPTION
## Summary

`h`, `filter_link`, and `display_tags` were recently migrated from `Rack::Utils` to `CGI` (7a4302d6), and `to_query_string`'s `SAFE_QPARAMS` set gained `only` (#6992) — but these helpers had no direct test coverage of their escaping behavior. Since they render HTML / query strings from user-controlled data (job args, tags, queue names), I added tests pinning that behavior:

- **`h`** — escapes `< > & " '` and coerces non-strings.
- **`filter_link`** — escapes the value and wraps it in the filter link by default; returns just the escaped value when `within` is nil.
- **`display_tags`** — escapes tag content in both the label class and the filter link.
- **`to_query_string`** — keeps only `SAFE_QPARAMS` (`page`/`direction`/`only`), drops unknown keys, and CGI-escapes values.

No `lib/` changes.

> Note: I intentionally did not test the `invalid byte sequence in UTF-8` rescue in `h` — on Ruby 3.2+ `CGI.escapeHTML` no longer raises on invalid bytes, so that branch isn't reliably triggerable and a test would be version-coupled/flaky.

## Testing

`bundle exec rake` is green (standard + lint:herb + full suite).