### PR TITLE
Add tests for to_display argument fallbacks

### DIFF
--- a/test/web_helpers_test.rb
+++ b/test/web_helpers_test.rb
@@ -187,6 +187,29 @@ describe "Web helpers" do
     assert_equal "Invalid job payload, args is nil", s
   end
 
+  describe "#to_display" do
+    it "falls back to to_s when inspect raises" do
+      arg = Object.new
+      def arg.inspect = raise("no inspect")
+      def arg.to_s = "fallback value"
+      assert_equal "fallback value", Helpers.new.to_display(arg)
+    end
+
+    it "returns a safe message when both inspect and to_s raise" do
+      arg = Object.new
+      def arg.inspect = raise("no inspect")
+      def arg.to_s = raise(ArgumentError, "no to_s")
+      assert_equal "Cannot display argument: [ArgumentError] no to_s", Helpers.new.to_display(arg)
+    end
+  end
+
+  it "renders an arg via the to_s fallback and escapes it" do
+    arg = Object.new
+    def arg.inspect = raise("no inspect")
+    def arg.to_s = "<danger>"
+    assert_equal "&lt;danger&gt;", Helpers.new.display_args([arg])
+  end
+
   it "query string escapes bad query input" do
     obj = Helpers.new
     assert_equal "page=B%3CH", obj.to_query_string("page" => "B<H")


### PR DESCRIPTION
## Summary

`display_args` renders job arguments in the Web UI, and `to_display` exists specifically so a job with a pathological argument can't crash the page — it falls back to `to_s` when `inspect` raises, and to a safe message when `to_s` also raises. Those rescue branches had no test coverage. This adds it (test-only, no `lib/` changes):

- `to_display` falls back to `to_s` when `inspect` raises.
- `to_display` returns `"Cannot display argument: [Class] message"` when both `inspect` and `to_s` raise.
- `display_args` renders an arg through the `to_s` fallback with HTML escaping applied (`<danger>` → `&lt;danger&gt;`).

## Testing

`bundle exec rake` is green (standard + lint:herb + full suite).