### PR TITLE
Use the requested pid in the Linux memory grabber

### DIFF
--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -235,7 +235,7 @@ module Sidekiq
     MEMORY_GRABBER = case RUBY_PLATFORM
     when /linux/
       ->(pid) {
-        IO.readlines("/proc/#{$$}/status").each do |line|
+        IO.readlines("/proc/#{pid}/status").each do |line|
           next unless line.start_with?("VmRSS:")
           break line.split[1].to_i
         end

--- a/test/launcher_test.rb
+++ b/test/launcher_test.rb
@@ -16,6 +16,15 @@ describe Sidekiq::Launcher do
       refute_nil kb
       assert kb > 0
     end
+
+    it "reads memory for the requested pid, not the current process" do
+      skip "Linux-only /proc memory grabber" unless RUBY_PLATFORM.match?(/linux/)
+      # A non-existent pid must hit /proc/<pid>/status and fail, proving the
+      # grabber honors its argument rather than always reading the current process.
+      assert_raises(Errno::ENOENT) do
+        Sidekiq::Launcher::MEMORY_GRABBER.call(999_999_999)
+      end
+    end
   end
 
   it "starts and stops" do


### PR DESCRIPTION
## Summary

The Linux branch of `MEMORY_GRABBER` (`lib/sidekiq/launcher.rb`) takes a `pid` argument but ignores it, reading the current process instead:

```ruby
when /linux/
  ->(pid) {
    IO.readlines("/proc/#{$$}/status").each do |line|   # reads $$ , not pid
      ...
```

The `darwin|bsd` branch correctly uses `pid` (`ps -o pid,rss -p #{pid}`). The bug has been latent since #4717 because the only caller is `memory_usage(::Process.pid)`, so `$$` and `pid` are always equal in practice — but the lambda is parameterized by `pid` and should honor it (and stay consistent across platforms).

Fix: read `/proc/#{pid}/status`.

## Testing

Adds a Linux-guarded regression test: calling the grabber with a non-existent pid must raise `Errno::ENOENT` (it now reads *that* pid's `/proc` entry). This fails against the old `$$` behavior (which silently returns the current process's RSS) and passes after the fix. It skips on non-Linux platforms where this lambda isn't used.

`bundle exec rake` is green (standard + lint:herb + full suite; the new test skips locally on macOS and runs on Linux CI).

> Note: I develop on macOS, so the Linux `/proc` path can't execute locally — this fix is by inspection/consistency with the `darwin|bsd` branch, and the regression test exercises it on Linux CI.