### PR TITLE
Add tests for launcher memory_usage and grabber pid handling

### DIFF
--- a/test/launcher_test.rb
+++ b/test/launcher_test.rb
@@ -25,6 +25,19 @@ describe Sidekiq::Launcher do
         Sidekiq::Launcher::MEMORY_GRABBER.call(999_999_999)
       end
     end
+
+    it "reads memory for a process other than the current one" do
+      kb = Sidekiq::Launcher::MEMORY_GRABBER.call(Process.ppid)
+      assert_kind_of Integer, kb
+      assert kb > 0
+    end
+
+    it "reports memory usage through #memory_usage" do
+      launcher = Sidekiq::Launcher.new(@config)
+      kb = launcher.send(:memory_usage, Process.pid)
+      assert_kind_of Integer, kb
+      assert kb > 0
+    end
   end
 
   it "starts and stops" do


### PR DESCRIPTION
## Summary

Follow-up test coverage for the memory grabber fixed in #7011 (`6b8e8945`). After that fix, coverage was still thin:

- `MEMORY_GRABBER` was only exercised with `$$` (current process), plus a Linux-only `ENOENT` check that skips on macOS.
- The `memory_usage(pid)` wrapper (`launcher.rb:251`) had no direct test.

This adds (test-only, no `lib/` changes):

- **Reads a different process by pid** — `MEMORY_GRABBER.call(Process.ppid)` returns a positive Integer. Runs on both Linux and macOS, exercising the by-pid read the #7011 fix enables (not just the current process).
- **`#memory_usage`** — returns a positive Integer for a given pid.

## Testing

`bundle exec rake` is green (standard + lint:herb + full suite). The pre-existing Linux-only grabber test still skips on macOS.