### PR TITLE
Fix 500 on the Busy page when count is negative

### DIFF
--- a/lib/sidekiq/paginator.rb
+++ b/lib/sidekiq/paginator.rb
@@ -60,6 +60,9 @@ module Sidekiq
 
     def page_items(items, pageidx = 1, page_size = 25)
       current_page = (pageidx.to_i < 1) ? 1 : pageidx.to_i
+      # A negative page_size makes Array#[] return nil instead of a slice, which
+      # would crash callers iterating the result (e.g. the Web UI Busy page).
+      page_size = 0 if page_size < 0
       pageidx = current_page - 1
       starting = pageidx * page_size
       items = items.to_a

--- a/test/paginator_test.rb
+++ b/test/paginator_test.rb
@@ -62,6 +62,11 @@ describe Sidekiq::Paginator do
       assert_equal [1, 0, []], @pager.page_items([], 1, 25)
       assert_equal [1, 0, []], @pager.page_items([], 5, 25)
     end
+
+    it "returns an empty page for a negative page size rather than nil" do
+      assert_equal [1, 3, []], @pager.page_items((1..3).to_a, 1, -5)
+      assert_equal [1, 0, []], @pager.page_items([], 1, -5)
+    end
   end
 
   describe "#page" do

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -130,6 +130,11 @@ describe Sidekiq::Web do
       assert_match(/exec=7/, last_response.body)
     end
 
+    it "does not crash on a negative count parameter" do
+      get "/busy?count=-1"
+      assert_equal 200, last_response.status
+    end
+
     it "can quiet all processes" do
       identity = "identity"
       signals_key = "#{identity}-signals"


### PR DESCRIPTION
## Summary

`Paginator#page_items` returns `nil` for the items slice when given a negative `page_size`, because `Array#[](start, negative)` returns `nil` rather than an empty array.

The Web UI passes the user-controlled `count` query param straight through as the page size:

```ruby
@count = (url_params("count") || 100).to_i
(@current_page, @total_size, @workset) = page_items(workset, url_params("page"), @count)
```

So `GET /busy?count=-1` makes `@workset` `nil`, and `busy.html.erb` (`@workset.size > 0`) then raises `NoMethodError: undefined method 'size' for nil` — a 500. It reproduces even with no running jobs (`[][0, -1]` is also `nil`).

The Redis-backed `page` path is unaffected (a negative size yields a `zrange(0, -6)` that returns an array), so the fix is localized to `page_items`: clamp a negative `page_size` to `0` so it always returns an array (matching the existing `count=0` behavior).

## Testing

- Paginator unit test: `page_items` returns `[page, total, []]` (not `nil`) for a negative page size.
- Web integration test: `GET /busy?count=-1` returns `200` instead of `500`.

Both fail before the change and pass after. `bundle exec rake` is green (standard + lint:herb + full suite).