### PR TITLE
Keep SortedEntry's in-memory score in sync after reschedule

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -627,6 +627,7 @@ module Sidekiq
       Sidekiq.redis do |conn|
         conn.zincrby(@parent.name, at.to_f - score, Sidekiq.dump_json(@item))
       end
+      @score = at.to_f
     end
 
     # Enqueue this job from the scheduled or dead set so it will

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -771,6 +771,17 @@ describe "API" do
       assert_equal(1, retries.count { |r| r.score > (now + 14) })
     end
 
+    it "keeps the in-memory entry consistent with Redis after reschedule" do
+      add_retry("foo1")
+      entry = Sidekiq::RetrySet.new.first
+      new_score = Time.now.to_f + 500
+
+      entry.reschedule(Time.at(new_score))
+
+      assert_in_delta new_score, entry.score, 0.001
+      assert_in_delta new_score, entry.at.to_f, 0.001
+    end
+
     it "prunes processes which have died" do
       data = {"pid" => rand(10_000), "hostname" => "app#{rand(1_000)}", "started_at" => Time.now.to_f}
       key = "#{data["hostname"]}:#{data["pid"]}"


### PR DESCRIPTION
## Summary

`Sidekiq::SortedEntry#reschedule` writes the new score to Redis via `zincrby` but never updates `@score`, so the in-memory entry's `#score` and `#at` keep returning the stale (pre-reschedule) values:

```ruby
entry = Sidekiq::ScheduledSet.new.first   # score => T0
entry.reschedule(Time.at(T0 + 500))
entry.score   # => T0 (stale, redis has T0+500)
entry.at      # => Time.at(T0) (stale)
```

The other `SortedEntry` mutators (`add_to_queue`/`retry`/`kill`/`delete`) all *remove* the entry from its set, so a stale entry there is moot. `reschedule` is the only mutator that **keeps the job alive in the same set with a new score** — making the drift between in-memory state and Redis a real footgun specifically here.

Fix: set `@score = at.to_f` after the `zincrby`.

## Testing

Adds a focused regression test that re-reads `entry.score` / `entry.at` after `reschedule` and asserts they reflect the new time. Fails before the change and passes after. The existing `"can reschedule jobs"` test is unaffected (it re-iterates the set, so it always sees fresh entries from Redis).

`bundle exec rake` is green (standard + lint:herb + full suite).