### PR TITLE
Fix IterableJobQuery cursor fallback (Struct member, not ivar)

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -1452,7 +1452,7 @@ module Sidekiq
         @cursor ||= begin
           Sidekiq.load_json(raw["c"])
         rescue JSON::ParserError
-          @raw["c"]
+          raw["c"]
         end
       end
 

--- a/test/iterable_job_query_test.rb
+++ b/test/iterable_job_query_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require "sidekiq/api"
+
+describe Sidekiq::IterableJobQuery do
+  before { @cfg = reset! }
+
+  def seed(jid, attrs)
+    Sidekiq.redis { |c| c.hset("it-#{jid}", attrs) }
+  end
+
+  it "raises ArgumentError when given nil" do
+    assert_raises(ArgumentError) { Sidekiq::IterableJobQuery.new(nil) }
+  end
+
+  it "returns nil for any jid when initialized with an empty array" do
+    q = Sidekiq::IterableJobQuery.new([])
+    assert_nil q["any-jid"]
+  end
+
+  it "returns nil for jids that have no iteration state" do
+    q = Sidekiq::IterableJobQuery.new(["missing"])
+    assert_nil q["missing"]
+  end
+
+  it "fetches iteration state and parses fields for a known jid" do
+    seed("jid-1", {"ex" => "5", "rt" => "1.5", "c" => '{"offset":100}'})
+    state = Sidekiq::IterableJobQuery.new(["jid-1"])["jid-1"]
+    refute_nil state
+    assert_equal 5, state.executions
+    assert_in_delta 1.5, state.runtime, 0.0001
+    assert_equal({"offset" => 100}, state.cursor)
+  end
+
+  it "exposes the cancellation marker when present" do
+    seed("jid-2", {"ex" => "1", "cancelled" => "1700000000"})
+    assert_equal 1_700_000_000, Sidekiq::IterableJobQuery.new(["jid-2"])["jid-2"].cancelled
+  end
+
+  it "falls back to the raw cursor string when JSON parsing fails" do
+    seed("jid-3", {"c" => "not-json"})
+    assert_equal "not-json", Sidekiq::IterableJobQuery.new(["jid-3"])["jid-3"].cursor
+  end
+
+  it "deduplicates and compacts the jid list" do
+    seed("jid-4", {"ex" => "2"})
+    q = Sidekiq::IterableJobQuery.new(["jid-4", "jid-4", nil])
+    assert_equal 2, q["jid-4"].executions
+  end
+end


### PR DESCRIPTION
## Summary

`Sidekiq::IterableJobQuery::State#cursor` tries to parse `raw["c"]` as JSON and intends to fall back to the raw string on `JSON::ParserError`:

```ruby
def cursor
  @cursor ||= begin
    Sidekiq.load_json(raw["c"])
  rescue JSON::ParserError
    @raw["c"]     # bug: @raw is nil
  end
end
```

`State` is a `Struct.new(:jid, :raw)`. On modern Ruby (3.x), `Struct` members are not exposed as `@`-prefixed instance variables, so `@raw` is `nil` — the rescue raises `NoMethodError: undefined method '[]' for nil` rather than returning the raw cursor. Reproduced on Ruby 3.4.5:

```
> s.cursor
NoMethodError: undefined method '[]' for nil
    api.rb:1455:in 'IterableJobQuery::State#cursor'
```

Drop the stray `@`.

## Testing

Adds `test/iterable_job_query_test.rb` covering the rescue path plus the rest of the surface (nil arg → `ArgumentError`, empty/missing → nil, executions/runtime/cursor/cancelled parsing, jid dedup/compact). The cursor-fallback test fails on current main with the `NoMethodError` above and passes after the fix.

`bundle exec rake` is green (standard + lint:herb + full suite).