### PR TITLE
Fix IterableJobQuery#bulk_fetch return-type comment

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -1416,7 +1416,7 @@ module Sidekiq
     private
 
     # Bulk-fetch iteration state for multiple JIDs in a single Redis pipeline.
-    # Returns a Hash of { jid => IterableJobState } for JIDs that have iteration state.
+    # Returns a Hash of { jid => State } for JIDs that have iteration state.
     def bulk_fetch(jids)
       raise ArgumentError unless jids
       jids_to_fetch = Array(jids).compact.uniq


### PR DESCRIPTION
## Summary

The doc comment on `Sidekiq::IterableJobQuery#bulk_fetch` says it returns a `Hash of { jid => IterableJobState }`, but the actual inner class is `Sidekiq::IterableJobQuery::State` (defined immediately below in the same file). Update the comment to match the code.

Spotted while writing tests for #7018 — small follow-up cleanup.