### PR TITLE
Honor the pool kwarg in Sidekiq::Stats::History

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -239,6 +239,7 @@ module Sidekiq
         raise ArgumentError if days_previous < 1 || days_previous > (5 * 365)
         @days_previous = days_previous
         @start_date = start_date || Time.now.utc.to_date
+        @pool = pool
       end
 
       def processed
@@ -259,13 +260,17 @@ module Sidekiq
 
         keys = dates.map { |datestr| "stat:#{stat}:#{datestr}" }
 
-        Sidekiq.redis do |conn|
+        with_redis do |conn|
           conn.mget(keys).each_with_index do |value, idx|
             stat_hash[dates[idx]] = value ? value.to_i : 0
           end
         end
 
         stat_hash
+      end
+
+      def with_redis(&block)
+        @pool ? @pool.with(&block) : Sidekiq.redis(&block)
       end
     end
   end

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -222,6 +222,29 @@ describe "API" do
           assert_raises(ArgumentError) { Sidekiq::Stats::History.new(2000) }
           assert Sidekiq::Stats::History.new(200)
         end
+
+        it "uses the provided pool instead of Sidekiq.redis" do
+          tracking_pool = Class.new {
+            attr_reader :with_calls
+
+            def initialize(real)
+              @real = real
+              @with_calls = 0
+            end
+
+            def with(&block)
+              @with_calls += 1
+              @real.with(&block)
+            end
+          }.new(@cfg.redis_pool)
+
+          today = Date.today.strftime("%Y-%m-%d")
+          @cfg.redis { |c| c.incrby("stat:processed:#{today}", 3) }
+
+          s = Sidekiq::Stats::History.new(1, pool: tracking_pool)
+          assert_equal({today => 3}, s.processed)
+          assert_operator tracking_pool.with_calls, :>, 0
+        end
       end
 
       describe "processed" do


### PR DESCRIPTION
## Summary

`Sidekiq::Stats::History.new(days, start_date = nil, pool: nil)` has accepted a `pool:` keyword since #5487 (the Sidekiq::Capsule introduction in 2022), but the kwarg was never assigned or used — `date_stat_hash` always reads from `Sidekiq.redis` regardless. Callers who passed a custom pool got their argument silently dropped.

Assign `@pool` in `initialize` and route `date_stat_hash` through a small `with_redis` helper that uses the passed pool when present and falls back to `Sidekiq.redis` otherwise. This matches the pool-arg precedent already in `Sidekiq::Deploy` (which takes a positional pool and uses `@pool.with`).

Non-breaking: existing callers (no `pool:` argument) continue to use `Sidekiq.redis`.

## Testing

Wraps `@cfg.redis_pool` in a small tracking decorator, passes it as `pool:` to `Stats::History`, and asserts the decorator's `.with` is invoked and the right hash comes back. `bundle exec rake` is green (standard + lint:herb + full suite).