### PR TITLE
Remove unused pool: kwarg from Sidekiq::Stats::History

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -234,7 +234,7 @@ module Sidekiq
     end
 
     class History
-      def initialize(days_previous, start_date = nil, pool: nil)
+      def initialize(days_previous, start_date = nil)
         # we only store five years of data in Redis
         raise ArgumentError if days_previous < 1 || days_previous > (5 * 365)
         @days_previous = days_previous


### PR DESCRIPTION
Per your direction on #7022: `Sidekiq::Stats::History.new`'s `pool:` keyword has been accepted (since #5487) but never used. Drop it from the signature.