### PR TITLE
Add tests for Sidekiq::JobRecord parsing and display contracts

### DIFF
--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -355,6 +355,34 @@ describe "API" do
       assert_equal ["foo"], Sidekiq::Queue.new.find_job(job_id).tags
     end
 
+    describe "JobRecord parsing and display" do
+      it "renders a malformed Redis payload safely instead of raising" do
+        j = Sidekiq::JobRecord.new("not-json", "default")
+        assert_equal({}, j.item)
+        assert_equal ["not-json"], j.args
+        assert_nil j.klass
+      end
+
+      it "redacts the final argument when the job is marked encrypted" do
+        payload = {"class" => "X", "args" => ["a", "b", "secret"], "queue" => "default", "encrypt" => true}
+        j = Sidekiq::JobRecord.new(payload, "default")
+        assert_equal ["a", "b", "[encrypted data]"], j.display_args
+      end
+
+      it "passes a Hash payload through without re-parsing" do
+        payload = {"class" => "X", "args" => [1, 2], "queue" => "default"}
+        j = Sidekiq::JobRecord.new(payload, "default")
+        assert_same payload, j.item
+      end
+
+      it "parses a JSON string payload into the item hash" do
+        json = Sidekiq.dump_json("class" => "X", "args" => [1, 2], "queue" => "default")
+        j = Sidekiq::JobRecord.new(json, "default")
+        assert_equal "X", j.klass
+        assert_equal [1, 2], j.args
+      end
+    end
+
     it "can delete jobs" do
       q = Sidekiq::Queue.new
       ApiJob.perform_async(1, "mike")


### PR DESCRIPTION
## Summary

Four cohesive tests covering substantive `JobRecord` behavior that the existing API tests only touched indirectly through specific Queue/ScheduledSet flows:

- **Malformed Redis payload** — a `JobRecord.new("not-json", "default")` doesn't raise; `item` is `{}`, `args` expose the raw string for Web UI display, `klass` is `nil`. This is the recovery path in `JobRecord#parse`'s `rescue JSON::ParserError`.
- **Encrypted arguments** — when `self["encrypt"]` is truthy, `display_args` redacts the final positional argument to `"[encrypted data]"` so secrets aren't surfaced to the Web UI.
- **Hash payload** — passed through to `#item` without re-parsing (the common path from `Queue#each` etc.).
- **JSON string payload** — parsed into the item hash and exposes `klass` and `args`.

Test-only, no `lib/` changes.

## Testing

`bundle exec rake` is green (standard + lint:herb + full suite).