### PR TITLE
Add tests for JobRecord error_backtrace decompression and error?

### DIFF
--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "helper"
 require "sidekiq/api"
+require "sidekiq/job_retry"
 require "active_job"
 require "action_mailer"
 
@@ -380,6 +381,45 @@ describe "API" do
         j = Sidekiq::JobRecord.new(json, "default")
         assert_equal "X", j.klass
         assert_equal [1, 2], j.args
+      end
+    end
+
+    describe "error information API" do
+      def compressed_backtrace(lines)
+        Sidekiq::JobRetry.new(@cfg).send(:compress_backtrace, lines)
+      end
+
+      it "decompresses the stored error_backtrace back into the original array" do
+        record = Sidekiq::JobRecord.new(
+          {"class" => "X", "args" => [], "error_backtrace" => compressed_backtrace(["a.rb:1", "b.rb:2"])},
+          "default"
+        )
+        assert_equal ["a.rb:1", "b.rb:2"], record.error_backtrace
+      end
+
+      it "returns nil for error_backtrace when none was stored, and memoizes the nil" do
+        record = Sidekiq::JobRecord.new({"class" => "X", "args" => []}, "default")
+        assert_nil record.error_backtrace
+        record.instance_variable_set(:@error_backtrace, "should-not-be-recomputed")
+        assert_equal "should-not-be-recomputed", record.error_backtrace
+      end
+
+      it "SortedEntry#error? reflects the presence of error_class" do
+        parent = Sidekiq::RetrySet.new
+        with_err = Sidekiq::SortedEntry.new(parent, Time.now.to_f,
+          Sidekiq.dump_json("class" => "X", "args" => [], "error_class" => "RuntimeError"))
+        without_err = Sidekiq::SortedEntry.new(parent, Time.now.to_f,
+          Sidekiq.dump_json("class" => "X", "args" => []))
+
+        assert with_err.error?
+        refute without_err.error?
+      end
+
+      it "SortedEntry inherits error_backtrace decompression from JobRecord" do
+        entry = Sidekiq::SortedEntry.new(Sidekiq::RetrySet.new, Time.now.to_f,
+          Sidekiq.dump_json("class" => "X", "args" => [],
+            "error_backtrace" => compressed_backtrace(["only-line.rb:1"])))
+        assert_equal ["only-line.rb:1"], entry.error_backtrace
       end
     end
 


### PR DESCRIPTION
## Summary

Four cohesive tests around the error-information API on `JobRecord` / `SortedEntry` — the contract the Web UI uses to render the retry / dead job error pages. Test-only, no `lib/` changes.

- **`error_backtrace` round-trip decompression** — using the real `JobRetry#compress_backtrace` to produce the stored payload, `JobRecord#error_backtrace` decompresses it back into the original array of backtrace lines.
- **`error_backtrace` nil memoization** — when no backtrace was stored, the result is `nil`, and the cached `@error_backtrace` is respected (so it's not re-decoded on every call).
- **`SortedEntry#error?`** — reflects the presence of `error_class` in the payload (true when set, false when absent).
- **`SortedEntry` inheritance** — confirms the `JobRecord#error_backtrace` decompression behavior is inherited through to `SortedEntry`.

## Testing

`bundle exec rake` is green (standard + lint:herb + full suite).