### PR TITLE
Add tests for Sidekiq::Process signal pushing and status helpers

### DIFF
--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -754,6 +754,46 @@ describe "API" do
       assert_equal "Can't stop an embedded process", e.message
     end
 
+    describe "Process signal and status" do
+      def make_process(identity, attrs = {})
+        Sidekiq::Process.new({"identity" => identity}.merge(attrs))
+      end
+
+      it "quiet! pushes TSTP to the identity-signals list with a 60s TTL" do
+        make_process("h1:1").quiet!
+
+        signals, ttl = @cfg.redis { |c|
+          [c.lrange("h1:1-signals", 0, -1), c.ttl("h1:1-signals")]
+        }
+        assert_equal ["TSTP"], signals
+        assert_operator ttl, :>, 0
+        assert_operator ttl, :<=, 60
+      end
+
+      it "stop! pushes TERM and dump_threads pushes TTIN to the same signals list" do
+        proc1 = make_process("h2:2")
+        proc1.stop!
+        proc1.dump_threads
+
+        # lpush prepends, so newest signal is first
+        signals = @cfg.redis { |c| c.lrange("h2:2-signals", 0, -1) }
+        assert_equal ["TTIN", "TERM"], signals
+      end
+
+      it "stopping? reflects the 'quiet' flag in the process info" do
+        refute make_process("h3:3").stopping?
+        assert make_process("h3:3", "quiet" => "true").stopping?
+        refute make_process("h3:3", "quiet" => "false").stopping?
+      end
+
+      it "leader? returns true only when the process identity matches dear-leader" do
+        @cfg.redis { |c| c.set("dear-leader", "h4:4") }
+
+        assert make_process("h4:4").leader?
+        refute make_process("other:9").leader?
+      end
+    end
+
     it "can enumerate workers" do
       w = Sidekiq::Workers.new
       assert_equal 0, w.size


### PR DESCRIPTION
## Summary

Four cohesive tests for `Sidekiq::Process`'s signal/status API — the contract behind the Web UI's per-process Quiet/Stop/Dump Threads buttons. The existing test for `quiet!`/`stop!` only asserts they raise on embedded processes; the actual signal-pushing side effect was never verified.

- **`quiet!`** pushes `TSTP` onto the `<identity>-signals` list with a 60s TTL (the contract that lets the running process pick up the signal without the list ever growing).
- **`stop!` + `dump_threads`** push `TERM` and `TTIN` onto the same per-identity signals list (and we confirm `lpush` ordering newest-first).
- **`stopping?`** reflects the `quiet` attribute in the process info hash (`"true"` string → true, anything else → false).
- **`leader?`** compares the process identity to the `dear-leader` Redis key — true only when the identity matches.

Test-only, no `lib/` changes.

## Testing

`bundle exec rake` is green (standard + lint:herb + full suite).