### PR TITLE
Add tests for Sidekiq's default logger initialization and formatters

### DIFF
--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -22,4 +22,28 @@ describe Sidekiq::Config do
     refute_match(/death_handlers/, @config.inspect)
     refute_match(/error_handlers/, @config.inspect)
   end
+
+  describe "default logger formatter" do
+    def with_env(key, value)
+      original = ENV[key]
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+      yield
+    ensure
+      original.nil? ? ENV.delete(key) : ENV[key] = original
+    end
+
+    it "uses WithoutTimestamp when running on Heroku (DYNO env var set)" do
+      with_env("DYNO", "web.1") do
+        cfg = Sidekiq::Config.new
+        assert_instance_of Sidekiq::Logger::Formatters::WithoutTimestamp, cfg.logger.formatter
+      end
+    end
+
+    it "uses Pretty when not running on Heroku" do
+      with_env("DYNO", nil) do
+        cfg = Sidekiq::Config.new
+        assert_instance_of Sidekiq::Logger::Formatters::Pretty, cfg.logger.formatter
+      end
+    end
+  end
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -132,6 +132,31 @@ describe "logger" do
     assert_predicate logger, :warn?
   end
 
+  it "emits plain (uncoloured) output with the Plain formatter" do
+    @logger.formatter = Sidekiq::Logger::Formatters::Plain.new
+    @logger.info("plain message")
+
+    line = @output.string
+    assert_match(/\AINFO \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z pid=#{$$} tid=\S+: plain message\n\z/, line)
+    refute_match(/\e\[/, line, "Plain formatter should not emit ANSI colour escapes")
+  end
+
+  it "joins Array context values with commas in format_context" do
+    fmt = Sidekiq::Logger::Formatters::Plain.new
+    formatted = fmt.send(:format_context, tags: ["a", "b", "c"], jid: "abc")
+    assert_equal " tags=a,b,c jid=abc", formatted
+  end
+
+  it "restores the previous Sidekiq::Context after Context.with even when the block raises" do
+    Sidekiq::Context.with(outer: "yes") do
+      assert_raises(RuntimeError) do
+        Sidekiq::Context.with(inner: "yes") { raise "boom" }
+      end
+      assert_equal({outer: "yes"}, Sidekiq::Context.current,
+        "Context.with must restore the prior context even on exception")
+    end
+  end
+
   def reset(io)
     io.truncate(0)
     io.rewind


### PR DESCRIPTION
## Summary

Five cohesive tests covering the logger lifecycle from default config through formatter output. Spans two test files because the contract spans two `lib` files — `Config` picks the formatter, `Logger` formats the output:

**`test/config_test.rb`** (default formatter selection in `Config#logger`):
- Picks `Formatters::WithoutTimestamp` when `ENV["DYNO"]` is set (Heroku convention).
- Picks `Formatters::Pretty` otherwise.

**`test/logger_test.rb`** (formatter behaviour and `Context.with`):
- `Formatters::Plain` (previously the only formatter not directly tested) emits an uncoloured log line with the documented shape (`INFO <iso8601> pid=… tid=…: msg`) and contains no ANSI colour escapes.
- `Base#format_context` joins `Array` context values with commas (the path that renders `:tags` and similar list-valued context — covered only indirectly before).
- `Sidekiq::Context.with` restores the prior thread-local context even when the block raises (the `ensure`-clause contract).

Test-only, no `lib/` changes.

## Testing

`bundle exec rake` is green (standard + lint:herb + full suite).