### PR TITLE
Add tests for Sidekiq::Client argument-validation contracts

### DIFF
--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -443,6 +443,34 @@ describe Sidekiq::Client do
           Sidekiq::Client.push_bulk("class" => QueuedJob, "args" => [[1]], "spread_interval" => :not_a_numeric)
         end
       end
+
+      it "rejects a non-Numeric scalar 'at' with the documented message" do
+        err = assert_raises(ArgumentError) do
+          Sidekiq::Client.push_bulk("class" => QueuedJob, "args" => [[1]], "at" => "soon")
+        end
+        assert_match(/Numeric or an Array of Numeric timestamps/, err.message)
+      end
+
+      it "rejects an empty Array 'at' with the documented message" do
+        err = assert_raises(ArgumentError) do
+          Sidekiq::Client.push_bulk("class" => QueuedJob, "args" => [[1]], "at" => [])
+        end
+        assert_match(/Numeric or an Array of Numeric timestamps/, err.message)
+      end
+
+      it "rejects an explicit jid when pushing more than one job" do
+        err = assert_raises(ArgumentError) do
+          Sidekiq::Client.push_bulk("class" => QueuedJob, "args" => [[1], [2]], "jid" => "abc")
+        end
+        assert_match(/Explicitly passing 'jid' when pushing more than one job/, err.message)
+      end
+
+      it "rejects providing both 'at' and 'spread_interval' with the documented message" do
+        err = assert_raises(ArgumentError) do
+          Sidekiq::Client.push_bulk("class" => QueuedJob, "args" => [[1]], "at" => Time.now.to_f, "spread_interval" => 10)
+        end
+        assert_match(/Only one of 'at' or 'spread_interval'/, err.message)
+      end
     end
 
     describe ".perform_bulk" do

--- a/test/sharding_test.rb
+++ b/test/sharding_test.rb
@@ -91,5 +91,25 @@ describe "Sharding" do
       assert_equal 0, ss.size
       assert_equal 0, q.size
     end
+
+    describe ".via" do
+      it "rejects a nil pool with the documented message" do
+        err = assert_raises(ArgumentError) { Sidekiq::Client.via(nil) {} }
+        assert_match(/No pool given/, err.message)
+      end
+
+      it "restores the previous thread-local pool even when the block raises" do
+        Thread.current[:sidekiq_redis_pool] = :outer
+
+        assert_raises(RuntimeError) do
+          Sidekiq::Client.via(@sh1) { raise "boom" }
+        end
+
+        assert_equal :outer, Thread.current[:sidekiq_redis_pool],
+          "expected Client.via to restore the prior thread-local pool on exception"
+      ensure
+        Thread.current[:sidekiq_redis_pool] = nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Six cohesive tests pinning the user-visible error contracts on `Sidekiq::Client`. The existing `assert_raises ArgumentError` block in `client_test.rb` checks _that_ each validation raises, but not _which_ contract — these new tests assert both the raise and the documented message, plus add the previously-uncovered `.via` contract in `sharding_test.rb`.

**`test/client_test.rb`** (`push_bulk` argument validation):
- Non-Numeric scalar `"at"` (e.g. `"soon"`) → documented message.
- Empty Array `"at"` → same message (covers the `Array(at).empty?` branch).
- Explicit `"jid"` with more than one job → documented message.
- Providing both `"at"` and `"spread_interval"` → documented message.

**`test/sharding_test.rb`** (`Client.via` contract):
- `Client.via(nil)` raises `ArgumentError` with `"No pool given"`.
- `Client.via` restores the previous thread-local `:sidekiq_redis_pool` even when the block raises (the `ensure`-clause contract that prevents pool leaks across sharded blocks).

Test-only, no `lib/` changes.

## Testing

`bundle exec rake` is green (standard + lint:herb + full suite).