### PR TITLE
Add tests for Setter#perform_in scheduling and .delay deprecations

### DIFF
--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -204,4 +204,41 @@ describe Sidekiq::Job do
       assert_match(/but :symbol is a Symbol/, error.message)
     end
   end
+
+  describe "#perform_in scheduling normalization" do
+    before { @config = reset! }
+
+    it "schedules a job into the future for a positive interval" do
+      MySetJob.perform_in(60)
+      assert_equal 1, Sidekiq::ScheduledSet.new.size
+      assert_equal 0, Sidekiq::Queue.new("foo").size
+    end
+
+    it "treats a number >= 1_000_000_000 as an absolute epoch timestamp" do
+      future_epoch = 2_000_000_000
+      MySetJob.perform_at(future_epoch)
+      entry = Sidekiq::ScheduledSet.new.first
+      refute_nil entry
+      assert_in_delta future_epoch, entry.at.to_f, 0.001
+    end
+
+    it "enqueues immediately instead of scheduling when the interval is in the past" do
+      MySetJob.perform_in(-60)
+      assert_equal 0, Sidekiq::ScheduledSet.new.size
+      assert_equal 1, Sidekiq::Queue.new("foo").size
+    end
+  end
+
+  describe ".delay / .delay_for / .delay_until" do
+    it "raise ArgumentError redirecting to perform_async / perform_in / perform_at" do
+      err = assert_raises(ArgumentError) { MySetJob.delay }
+      assert_match(/call \.perform_async/, err.message)
+
+      err = assert_raises(ArgumentError) { MySetJob.delay_for(10) }
+      assert_match(/call \.perform_in/, err.message)
+
+      err = assert_raises(ArgumentError) { MySetJob.delay_until(Time.now + 10) }
+      assert_match(/call \.perform_at/, err.message)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Four cohesive tests pinning `Sidekiq::Job`'s deferred-execution contracts — the `Setter#at` normalization that powers `perform_in` / `perform_at`, plus the documented redirects from the legacy `delay*` methods. None of these were directly covered.

- **`perform_in` with a positive interval** schedules into `ScheduledSet`, not the queue.
- **`perform_at` with a number `>= 1_000_000_000`** is treated as an absolute epoch timestamp rather than a relative offset — the documented optimization in `Setter#at` for absolute scheduling.
- **`perform_in` with a past interval** skips scheduling and enqueues immediately (the `ts > now` branch — the "scheduled in the past" optimization).
- **`.delay` / `.delay_for` / `.delay_until`** each raise `ArgumentError` redirecting the caller to the modern `perform_async` / `perform_in` / `perform_at` method.

Test-only, no `lib/` changes.

## Testing

`bundle exec rake` is green (standard + lint:herb + full suite).