### PR TITLE
Fix crash on ?count=0 in Web UI pagination

### DIFF
--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -236,6 +236,13 @@ describe Sidekiq::Web do
     refute_match(/\b1003\b/, last_response.body)
   end
 
+  it "does not crash on a zero count parameter" do
+    @config.redis { |conn| conn.lpush("queue:default", Sidekiq.dump_json(args: [1])) }
+
+    get "/queues/default?count=0"
+    assert_equal 200, last_response.status
+  end
+
   it "can delete a queue" do
     @config.redis do |conn|
       conn.rpush("queue:foo", "{\"args\":[],\"enqueued_at\":1567894960}")
@@ -356,6 +363,13 @@ describe Sidekiq::Web do
     assert_equal 200, last_response.status
     refute_match(/found/, last_response.body)
     assert_match(/HardJob/, last_response.body)
+  end
+
+  it "does not crash on a zero count parameter" do
+    add_retry
+
+    get "/retries?count=0"
+    assert_equal 200, last_response.status
   end
 
   it "displays iteration state on retry detail page" do
@@ -488,6 +502,13 @@ describe Sidekiq::Web do
     assert_equal 200, last_response.status
     refute_match(/found/, last_response.body)
     assert_match(/HardJob/, last_response.body)
+  end
+
+  it "does not crash on a zero count parameter" do
+    add_scheduled
+
+    get "/scheduled?count=0"
+    assert_equal 200, last_response.status
   end
 
   it "can display a single scheduled job" do
@@ -810,6 +831,13 @@ describe Sidekiq::Web do
       get "morgue"
       assert_equal 200, last_response.status
       assert_match(/#{score}/, last_response.body)
+    end
+
+    it "does not crash on a zero count parameter" do
+      add_dead
+
+      get "/morgue?count=0"
+      assert_equal 200, last_response.status
     end
 
     it "can delete multiple dead" do

--- a/web/views/_paging.html.erb
+++ b/web/views/_paging.html.erb
@@ -19,7 +19,7 @@
         </li>
       <% end %>
       <li class="<%= 'disabled' if @total_size <= @current_page * @count %>">
-        <a href="<%= url %>?<%= qparams(page: (@total_size.to_f / @count).ceil) %>">&raquo;</a>
+        <a href="<%= url %>?<%= qparams(page: @count > 0 ? (@total_size.to_f / @count).ceil : 1) %>">&raquo;</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
_paging.html.erb divides `@total_size` by `@count` to build the "jump to last page" link, and `@count` comes straight from the `count` query param (`url_params("count").to_i`). Hitting `/retries?count=0`, `/scheduled?count=0`, `/morgue?count=0`, or `/queues/:name?count=0` on any non-empty set raises `FloatDomainError: Infinity` instead of rendering the page.

It's basically the same class of bug as #7014 (fixed for `page_items`/the Busy page), just reachable through the other four paginated views since they don't share that guard — `_paging.html.erb` itself has no protection against `@count` being zero or negative. There's actually an older closed issue for this too (#4870), but it never got a fix.

Falls back to page 1 for the "last page" link when count isn't positive, and added a regression test for each of the four affected views (queue, retries, scheduled, morgue).