### PR TITLE
Convert help screen hotkeys to table

### DIFF
--- a/lib/sidekiq/tui.rb
+++ b/lib/sidekiq/tui.rb
@@ -105,31 +105,40 @@ module Sidekiq
                 @tui.constraint_length(4)
               ]
             )
-            content = @tui.block(
-              title: " #{Sidekiq::NAME} ",
-              borders: [:all],
-              title_style: @tui.style(fg: :light_red, modifiers: [:bold]),
-              children: [
-                # TODO convert to table
-                @tui.paragraph(
-                  text: [
-                    @tui.text_line(spans: ["Welcome to the Sidekiq Terminal UI"], alignment: :center),
-                    @tui.text_line(spans: [
-                      @tui.text_span(content: "Global hotkeys")
-                    ]),
-                    @tui.text_line(spans: []),
-                    hotkey_line("Esc", "Close this window"),
-                    hotkey_line("←/→", "Move between tabs"),
-                    hotkey_line("h/l", "Move to prev/next page of data"),
-                    hotkey_line("j/k", "Move to prev/next row in current page"),
-                    hotkey_line("x", "Select/deselect current row"),
-                    hotkey_line("A", "Select/deselect All rows in current page"),
-                    hotkey_line("q", "Quit")
-                  ]
-                )
-              ]
+            
+            help_data = [
+              ["Esc", "Close this window"],
+              ["←/→", "Move between tabs"],
+              ["h/l", "Move to prev/next page of data"],
+              ["j/k", "Move to prev/next row in current page"],
+              ["x", "Select/deselect current row"],
+              ["A", "Select/deselect All rows in current page"],
+              ["q", "Quit"]
+            ]
+            
+            # striped styling like other tables in the app
+            help_rows = help_data.map.with_index { |cells, idx|
+              @tui.table_row(
+                cells: cells,
+                style: idx.even? ? nil : @tui.style(bg: :dark_gray)
+              )
+            }
+            
+            table = @tui.table(
+              block: @tui.block(
+                title: " #{Sidekiq::NAME} - Welcome to the Sidekiq Terminal UI ",
+                borders: [:all],
+                title_style: @tui.style(fg: :light_red, modifiers: [:bold])
+              ),
+              header: ["Key", "Action"],
+              rows: help_rows,
+              widths: [
+                @tui.constraint_length(15),
+                @tui.constraint_fill(1)
+              ],
+              column_spacing: 1
             )
-            frame.render_widget(content, main_area)
+            frame.render_widget(table, main_area)
             controls = @tui.block(
               title: t("Controls"),
               borders: [:all],


### PR DESCRIPTION
## Summary

This PR replaces the help screen's hotkey list, which was previously rendered as a paragraph, with a proper `Table` widget using `ratatui_ruby`.

This addresses the existing `# TODO convert to table` in `lib/sidekiq/tui.rb`.

## Changes

- Replace paragraph-based hotkey list with a `Table` widget.
- Add a header row (`Key` / `Action`).
- Render each hotkey as a separate table row.
- Preserve the existing help screen functionality and controls.

## Before

The help screen displayed hotkeys as plain text inside a paragraph.

## After

The help screen displays the hotkeys in a structured table, making them easier to scan and aligning with the existing TUI components used elsewhere.

## Testing

- Started the TUI using `bundle exec ruby bin/kiq`.
- Opened the Help screen.
- Verified the table renders correctly and all existing hotkeys are displayed.

Before screenshot - 
<img width="1365" height="634" alt="image" src="https://github.com/user-attachments/assets/7e287c0d-6d60-4507-876f-fd6df29aafe4" />


After -

<img width="1365" height="634" alt="image" src="https://github.com/user-attachments/assets/eea05630-59c7-4829-95b6-40e43ede6394" />
