### PR TITLE
TUI: Convert help screen hotkeys to table

### DIFF
--- a/lib/sidekiq/tui.rb
+++ b/lib/sidekiq/tui.rb
@@ -105,31 +105,40 @@ module Sidekiq
                 @tui.constraint_length(4)
               ]
             )
-            content = @tui.block(
-              title: " #{Sidekiq::NAME} ",
-              borders: [:all],
-              title_style: @tui.style(fg: :light_red, modifiers: [:bold]),
-              children: [
-                # TODO convert to table
-                @tui.paragraph(
-                  text: [
-                    @tui.text_line(spans: ["Welcome to the Sidekiq Terminal UI"], alignment: :center),
-                    @tui.text_line(spans: [
-                      @tui.text_span(content: "Global hotkeys")
-                    ]),
-                    @tui.text_line(spans: []),
-                    hotkey_line("Esc", "Close this window"),
-                    hotkey_line("←/→", "Move between tabs"),
-                    hotkey_line("h/l", "Move to prev/next page of data"),
-                    hotkey_line("j/k", "Move to prev/next row in current page"),
-                    hotkey_line("x", "Select/deselect current row"),
-                    hotkey_line("A", "Select/deselect All rows in current page"),
-                    hotkey_line("q", "Quit")
-                  ]
-                )
-              ]
+            
+            help_data = [
+              ["Esc", "Close this window"],
+              ["←/→", "Move between tabs"],
+              ["h/l", "Move to prev/next page of data"],
+              ["j/k", "Move to prev/next row in current page"],
+              ["x", "Select/deselect current row"],
+              ["A", "Select/deselect All rows in current page"],
+              ["q", "Quit"]
+            ]
+            
+            # striped styling like other tables in the app
+            help_rows = help_data.map.with_index { |cells, idx|
+              @tui.table_row(
+                cells: cells,
+                style: idx.even? ? nil : @tui.style(bg: :dark_gray)
+              )
+            }
+            
+            table = @tui.table(
+              block: @tui.block(
+                title: " #{Sidekiq::NAME} - Welcome to the Sidekiq Terminal UI ",
+                borders: [:all],
+                title_style: @tui.style(fg: :light_red, modifiers: [:bold])
+              ),
+              header: ["Key", "Action"],
+              rows: help_rows,
+              widths: [
+                @tui.constraint_length(15),
+                @tui.constraint_fill(1)
+              ],
+              column_spacing: 1
             )
-            frame.render_widget(content, main_area)
+            frame.render_widget(table, main_area)
             controls = @tui.block(
               title: t("Controls"),
               borders: [:all],

--- a/test/tui_test.rb
+++ b/test/tui_test.rb
@@ -93,4 +93,83 @@ describe "Sidekiq::TUI::BaseTab" do
       assert_equal "99.999 KB", tab.format_memory(99_999)
     end
   end
+
+  describe "#striped_rows" do
+    it "applies alternating dark_gray background styling to rows" do
+      tab = ConcreteTab.new(FakeTUIParent.new)
+      
+      # Mock tui object with minimal required methods
+      mock_tui = Object.new
+      def mock_tui.table_row(cells:, style: nil)
+        {cells: cells, style: style}
+      end
+      def mock_tui.style(bg:)
+        {bg: bg}
+      end
+      
+      rows_data = [
+        ["Row 1", "Data 1"],
+        ["Row 2", "Data 2"],
+        ["Row 3", "Data 3"]
+      ]
+      
+      result = tab.striped_rows(mock_tui, rows_data)
+      
+      assert_equal 3, result.length
+      assert_nil result[0][:style] # Even rows (0-indexed) have no style
+      assert_equal({bg: :dark_gray}, result[1][:style]) # Odd rows get dark_gray
+      assert_nil result[2][:style]
+    end
+  end
+end
+
+describe "Sidekiq::TUI Help Table" do
+  it "defines correct help data structure" do
+    help_data = [
+      ["Esc", "Close this window"],
+      ["←/→", "Move between tabs"],
+      ["h/l", "Move to prev/next page of data"],
+      ["j/k", "Move to prev/next row in current page"],
+      ["x", "Select/deselect current row"],
+      ["A", "Select/deselect All rows in current page"],
+      ["q", "Quit"]
+    ]
+    
+    # Verify structure
+    assert_equal 7, help_data.length
+    help_data.each do |row|
+      assert_equal 2, row.length, "Each help row should have exactly 2 columns"
+      assert_kind_of String, row[0], "Key should be a string"
+      assert_kind_of String, row[1], "Action description should be a string"
+    end
+  end
+  
+  it "includes all essential hotkeys in help data" do
+    help_data = [
+      ["Esc", "Close this window"],
+      ["←/→", "Move between tabs"],
+      ["h/l", "Move to prev/next page of data"],
+      ["j/k", "Move to prev/next row in current page"],
+      ["x", "Select/deselect current row"],
+      ["A", "Select/deselect All rows in current page"],
+      ["q", "Quit"]
+    ]
+    
+    keys = help_data.map(&:first)
+    
+    # Essential keys should be present
+    assert_includes keys, "Esc"
+    assert_includes keys, "←/→"
+    assert_includes keys, "q"
+    assert_includes keys, "x"
+    assert_includes keys, "A"
+  end
+  
+  it "help table has proper column headers" do
+    headers = ["Key", "Action"]
+    
+    assert_equal 2, headers.length
+    assert_equal "Key", headers[0]
+    assert_equal "Action", headers[1]
+  end
 end


### PR DESCRIPTION
## Summary

This PR replaces the help screen's hotkey list, which was previously rendered as a paragraph, with a proper `Table` widget using `ratatui_ruby`.

This addresses the existing `# TODO convert to table` in `lib/sidekiq/tui.rb`.

## Changes

- Replace paragraph-based hotkey list with a `Table` widget.
- Add a header row (`Key` / `Action`).
- Render each hotkey as a separate table row.
- Preserve the existing help screen functionality and controls.

## Before

The help screen displayed hotkeys as plain text inside a paragraph.

## After

The help screen displays the hotkeys in a structured table, making them easier to scan and aligning with the existing TUI components used elsewhere.

## Testing

- Started the TUI using `bundle exec ruby bin/kiq`.
- Opened the Help screen.
- Verified the table renders correctly and all existing hotkeys are displayed.


# Test results 

Before - 
<img width="1365" height="634" alt="image (4)" src="https://github.com/user-attachments/assets/e358af2f-456d-43c4-828f-ce9bde9ae802" />


After - 

<img width="1365" height="634" alt="image" src="https://github.com/user-attachments/assets/35b0b6bf-d841-4378-a281-fa0233dbff04" />
