### PR TITLE
TUI: Render controls dynamically based on terminal width

### DIFF
--- a/lib/sidekiq/tui.rb
+++ b/lib/sidekiq/tui.rb
@@ -154,17 +154,36 @@ module Sidekiq
     def render_controls(frame, area)
       active_keys = current_tab.controls.filter { |hash| hash[:description] }
 
-      # Split controls into two lines, 8 is arbitrary
-      # TODO Dynamically split based on term width?
-      first = active_keys[...8]
+      # Dynamically split controls based on terminal width
+      # Estimate space needed: each control needs ~key_length + description_length + 4 chars for ": " and spacing
+      available_width = area.width - 4 # Account for borders
+      
       lines = []
-      lines << controls_line(first)
-
-      last = active_keys[8...]
-      lines << if last && last.size > 0
-        controls_line(last)
-      else
-        @tui.text_line(spans: [])
+      current_line = []
+      current_width = 0
+      
+      active_keys.each do |hash|
+        # Estimate control width: key + ": " + description + "  " (spacing)
+        key_text = hash[:display] || hash[:code]
+        control_width = key_text.length + 2 + t(hash[:description]).length + 2
+        
+        if current_width + control_width > available_width && !current_line.empty?
+          # Start a new line
+          lines << controls_line(current_line)
+          current_line = [hash]
+          current_width = control_width
+        else
+          current_line << hash
+          current_width += control_width
+        end
+      end
+      
+      # Add the last line
+      lines << controls_line(current_line) unless current_line.empty?
+      
+      # Ensure we have at least 2 lines for layout consistency
+      while lines.length < 2
+        lines << @tui.text_line(spans: [])
       end
 
       footer = [


### PR DESCRIPTION
## Summary

This PR replaces the fixed split of controls after 8 items with dynamic wrapping based on the available terminal width.

This addresses the existing `# TODO Dynamically split based on term width?` in `lib/sidekiq/tui.rb`.

## Changes

- Remove the hardcoded split after 8 controls.
- Dynamically wrap controls based on the available terminal width.
- Support multiple lines of controls when needed.
- Preserve the existing controls and functionality.

## Before

The controls were always split after the first 8 items, regardless of the terminal width.

## After

The controls automatically wrap based on the terminal width, making better use of available space on wider terminals while remaining readable on narrower ones.

## Testing

- Started the TUI using `bundle exec ruby bin/kiq`.
- Verified the controls wrap correctly on different terminal widths.
- Verified all controls are displayed and continue to function as expected.

# Test results

### Before
<img width="802" height="412" alt="image" src="https://github.com/user-attachments/assets/6684d762-86e7-4a69-857d-e33d09830557" />

### After
<img width="802" height="412" alt="image" src="https://github.com/user-attachments/assets/93d80cc0-9a0f-4337-ab13-9e61fb44ede3" />
