### PR TITLE
Metrics: draw deploy marks from every day the queried window spans

### DIFF
--- a/lib/sidekiq/metrics/query.rb
+++ b/lib/sidekiq/metrics/query.rb
@@ -171,8 +171,10 @@ module Sidekiq
         [].tap do |result|
           days = (time_range.begin.utc.to_date..time_range.end.utc.to_date)
           marks = @pool.with { |c|
-            days.flat_map { |day| c.hgetall("#{day.strftime("%Y%m%d")}-marks").to_a }
-          }
+            c.pipelined { |pipeline|
+              days.each { |day| pipeline.hgetall("#{day.strftime("%Y%m%d")}-marks") }
+            }
+          }.flat_map(&:to_a)
 
           marks.each do |timestamp, label|
             time = Time.parse(timestamp)

--- a/lib/sidekiq/metrics/query.rb
+++ b/lib/sidekiq/metrics/query.rb
@@ -169,7 +169,10 @@ module Sidekiq
 
       def fetch_marks(time_range, granularity)
         [].tap do |result|
-          marks = @pool.with { |c| c.hgetall("#{@time.strftime("%Y%m%d")}-marks") }
+          days = (time_range.begin.utc.to_date..time_range.end.utc.to_date)
+          marks = @pool.with { |c|
+            days.flat_map { |day| c.hgetall("#{day.strftime("%Y%m%d")}-marks").to_a }
+          }
 
           marks.each do |timestamp, label|
             time = Time.parse(timestamp)

--- a/test/metrics_test.rb
+++ b/test/metrics_test.rb
@@ -104,6 +104,18 @@ describe Sidekiq::Metrics do
       assert_equal 1, rs.size
       assert_equal "cafed00d - some git summary line", rs[floor]
     end
+
+    it "returns marks from every day the queried window spans" do
+      whence = Time.utc(2022, 7, 22, 22, 3, 0)
+      d = Sidekiq::Deploy.new
+      d.mark!(at: whence - 26 * 60 * 60, label: "yesterday deploy")
+      d.mark!(at: whence, label: "today deploy")
+
+      q = Sidekiq::Metrics::Query.new(now: whence)
+      labels = q.top_jobs(hours: 72).marks.map(&:label)
+      assert_includes labels, "today deploy"
+      assert_includes labels, "yesterday deploy"
+    end
   end
 
   describe "histograms" do


### PR DESCRIPTION
Fixes #7053.

`Sidekiq::Deploy#mark!` stores marks under per-day keys (`YYYYMMDD-marks`, 90-day TTL), but `Metrics::Query#fetch_marks` read only today's key before applying the `time_range` filter — so on any window longer than the current UTC day (including the Metrics page's own 72h period) deploys from previous days silently vanished from the graphs while still present in Redis.

This reads every date key the queried window spans (at most 4 `HGETALL`s for the 72h view, each against a small hash) and keeps the existing range filter. Windows within a single UTC day behave exactly as before (one key, as today).

Test included: red on current `main` (`Expected ["today deploy"] to include "yesterday deploy"`), green with the fix. Full `bundle exec rake` (standard + lint:herb + test, 749 runs) passes.
